### PR TITLE
Follow-up: SelfCheckSolution component

### DIFF
--- a/docs/Komponentengalerie/self-check.md
+++ b/docs/Komponentengalerie/self-check.md
@@ -82,7 +82,7 @@ Folgendes Beispiel enthält ein Selfcheck-Szenario, in dem die Musterlösung (au
 
 Erstelle auch für diese Aufgabe eine Lösung.
 
-<SelfCheckSolution title="Lösung zur Aufgabe 3" open>
+<SelfCheckSolution title="Lösung zur Aufgabe 2" open>
 Lösung zur zweiten Aufgabe 🥳
 </SelfCheckSolution>
 :::
@@ -114,7 +114,7 @@ Lösung zur zweiten Aufgabe 🥳
 
 Erstelle auch für diese Aufgabe eine Lösung.
 
-<SelfCheckSolution title="Lösung zur Aufgabe 3" open>
+<SelfCheckSolution title="Lösung zur Aufgabe 2" open>
 Lösung zur zweiten Aufgabe 🥳
 </SelfCheckSolution>
 :::

--- a/docs/Komponentengalerie/self-check.md
+++ b/docs/Komponentengalerie/self-check.md
@@ -3,6 +3,7 @@ page_id: f632a479-cfe4-4a98-848a-a0dd0e0f6535
 ---
 
 import SelfCheckTaskState from '@tdev-components/documents/SelfCheck/SelfCheckTaskState';
+import SelfCheckSolution from '@tdev-components/documents/SelfCheck/SelfCheckSolution';
 import SelfCheckContent from '@tdev-components/documents/SelfCheck/SelfCheckContent';
 import SelfCheck from '@tdev-components/documents/SelfCheck';
 import { SelfCheckStateType } from '@tdev-components/documents/SelfCheck/models';
@@ -11,23 +12,23 @@ import BrowserWindow from '@tdev-components/BrowserWindow';
 
 # Selfcheck
 
-Mit den Komponenten `<SelfCheck>` und `<SelfCheckTaskState>` lässt sich ein einfaches "Selfcheck-Szenario" (also eine Übung mit Selbstkontrolle) umsetzen:
+Mit den drei Komponenten `<SelfCheck>`, `<SelfCheckTaskState>` und `<SelfCheckSolution>` lässt sich ein einfaches "Selfcheck-Szenario" (also eine Übung mit Selbstkontrolle) umsetzen:
 
-:::warning[Solution ID]
-Die `solutionId` auf der `<Selfcheck>`-Komponente und die `id` auf der `<Solution>` müssen identisch sein.
+:::warning[Erforderliche Elemente und Eigenschaften]
+In jedem `<SelfCheck>`-Kontext müssen je genau ein `<SelfCheckTaskState>` und eine `<SelfCheckSolution>` verwendet werden. Zudem müssen auf dem `<SelfCheck>`-Element eine `taskStateId` und eine `solutionId` definiert werden.
 :::
 
 ```md
 <SelfCheck taskStateId="841c3390-17d5-42e5-bd9f-e50e46c97625" solutionId="71ed3d23-19d4-4575-9117-9cac09749223">
-    :::note[Aufgabe 1]
-    <SelfCheckTaskState />
+:::note[Aufgabe 1]
+<SelfCheckTaskState />
 
-    Erstelle eine Lösung für diese Aufgabe.
+Erstelle eine Lösung für diese Aufgabe.
 
-    <Solution id="71ed3d23-19d4-4575-9117-9cac09749223">
-    Hallo Welt 🌍
-    </Solution>
-    :::
+<SelfCheckSolution>
+Hallo Welt 🌍
+</SelfCheckSolution>
+:::
 </SelfCheck>
 ```
 
@@ -35,15 +36,17 @@ Die `solutionId` auf der `<Selfcheck>`-Komponente und die `id` auf der `<Solutio
 <SelfCheck taskStateId="841c3390-17d5-42e5-bd9f-e50e46c97625" solutionId="71ed3d23-19d4-4575-9117-9cac09749223">
 :::note[Aufgabe 1]
 <SelfCheckTaskState />
+
 Erstelle eine Lösung für diese Aufgabe.
-<Solution id="71ed3d23-19d4-4575-9117-9cac09749223">
+
+<SelfCheckSolution>
 Hallo Welt 🌍
-</Solution>
+</SelfCheckSolution>
 :::
 </SelfCheck>
 </BrowserWindow>
 
-Die im Task State verfügbaren Zustände sind abhängig davon, ob die Lösung bereits verfügbar ist.
+Die im Task State verfügbaren Zustände sind abhängig davon, ob die Lösung bereits verfügbar ist. Durch die Verwendung der `<SelfCheckSolution>` ist das Lösungselement zudem nur dann sichtbar, wenn sich der Task State im Status _Warten auf Musterlösung_ oder _Korrektur_ befindet (siehe auch [unten](#statusabhängige-sichtbarkeit)). 
 
 Die Interpretation der verschiedenen Zustände ist wie folgt vorgesehen:
 
@@ -56,9 +59,9 @@ Die Interpretation der verschiedenen Zustände ist wie folgt vorgesehen:
 | :mdi[checkbox-marked-outline]{.green} Fertig           | Die Bearbeitung der Aufgabe ist abgeschlossen - die eigene Antwort des Schülers ist nun vollständig und korrekt.                                                                                                  |
 
 ## Statusabhängige Sichtbarkeit
-Wenn gewisse Elemente (z.B. die Musterlösung, Hinweise, etc.) nur während bestimmten Zuständen sichtbar sein sollen, eignet sich die `SelfCheckContent`-Komponente.
+Wenn gewisse Elemente (z.B. die Musterlösung, Hinweise, etc.) nur während bestimmten Zuständen sichtbar sein sollen, eignen sich die Komponenten `<SelfCheckSolution>` (für die Lösung; muss pro `<SelfCheck>` genau einmal vorhanden sein) und `<SelfCheckContent>` (für beliebige Inhalte). Das hier beschriebene Verhalten ist für beide Komponenten identisch.
 
-Standardmässig zeigt sie ihren Inhalt nur in den Zuständen _Warten auf Musterlösung_ und _Korrektur_ an. Dies kann mit den Eigenschaften `visibleFrom` und `visibleTo` angepasst werden. Es stehen dafür je folgende Konstanten zur Verfügung:
+Standardmässig zeigen diese Komponenten ihren Inhalt nur in den Zuständen _Warten auf Musterlösung_ und _Korrektur_ an. Dies kann mit den Eigenschaften `visibleFrom` und `visibleTo` angepasst werden. Es stehen dafür je folgende Konstanten zur Verfügung:
 
 | Zustand                                                | Konstante                               |
 |--------------------------------------------------------|-----------------------------------------|
@@ -68,74 +71,70 @@ Standardmässig zeigt sie ihren Inhalt nur in den Zuständen _Warten auf Musterl
 | :mdi[star]{color=gold} Korrektur                       | `SelfCheckStateType.Reviewing`          |
 | :mdi[checkbox-marked-outline]{.green} Fertig           | `SelfCheckStateType.Done`               |
 
-Zudem zeigt sie ihren Inhalt für Lehrpersonen standardmässig immer an. Dieses Verhalten kann mit `<SelfCheckContent alwaysVisibleForTeacher={false}>` angepasst werden.
+Zudem zeigt sie ihren Inhalt für Lehrpersonen standardmässig immer an. Dieses Verhalten kann mit `<SelfCheckContent alwaysVisibleForTeacher={false}>` (resp. `<SelfCheckSolution alwaysVisibleForTeacher={false}>`) angepasst werden.
 
 Folgendes Beispiel enthält ein Selfcheck-Szenario, in dem die Musterlösung (ausser für Lehrpersonen) nur in den Zuständen _Warten auf Musterlösung_ (als nicht-verfügbar) und _Korrektur_ angezeigt wird. Zudem wird den Zuständen _Frage_, _Warten auf Musterlösung_ und _Korrektur_ je ein spezifischer Hinweis angezeigt. Diese Hinweise sind auch für Lehrpersonen nur im entsprechenden Zustand sichtbar.
 
 ```md
 <SelfCheck taskStateId="df3313a5-c18f-4220-9dfe-cf4314c1b7b9" solutionId="e92b6f49-396e-48bc-8a6c-4ca94947210d">
-    :::note[2. Aufgabe]
-    <SelfCheckTaskState />
-    
-    Erstelle auch für diese Aufgabe eine Lösung.
-    
-    <SelfCheckContent>
-        <Solution id="e92b6f49-396e-48bc-8a6c-4ca94947210d">
-        Lösung zur zweiten Aufgabe 🥳
-        </Solution>
-    </SelfCheckContent>
+:::note[2. Aufgabe]
+<SelfCheckTaskState />
+
+Erstelle auch für diese Aufgabe eine Lösung.
+
+<SelfCheckSolution>
+Lösung zur zweiten Aufgabe 🥳
+</SelfCheckSolution>
+:::
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleTo={SelfCheckStateType.WaitingForSolution}>
+    :::info[Auf Musterlösung warten]
+    Die Lehrperson wird dir die Musterlösung bald freischalten.
     :::
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleTo={SelfCheckStateType.WaitingForSolution}>
-        :::info[Auf Musterlösung warten]
-        Die Lehrperson wird dir die Musterlösung bald freischalten.
-        :::
-    </SelfCheckContent>
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Reviewing}>
-        :::info[Selbstständig korrigieren]
-        Vergleiche deine Lösung nun mit der Musterlösung und korrigiere deine Antwort.
-        :::
-    </SelfCheckContent>
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Question} visibleTo={SelfCheckStateType.Question}>
-        :::info[Frage?]
-        Wenn du während des Unterrichts eine Frage hast, dann kannst du jederzeit die Lehrperson rufen.
-        :::
-    </SelfCheckContent>
+</SelfCheckContent>
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Reviewing}>
+    :::info[Selbstständig korrigieren]
+    Vergleiche deine Lösung nun mit der Musterlösung und korrigiere deine Antwort.
+    :::
+</SelfCheckContent>
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Question} visibleTo={SelfCheckStateType.Question}>
+    :::info[Frage?]
+    Wenn du während des Unterrichts eine Frage hast, dann kannst du jederzeit die Lehrperson rufen.
+    :::
+</SelfCheckContent>
 </SelfCheck>
 ```
 
 <BrowserWindow>
 <SelfCheck taskStateId="df3313a5-c18f-4220-9dfe-cf4314c1b7b9" solutionId="e92b6f49-396e-48bc-8a6c-4ca94947210d">
-    :::note[2. Aufgabe]
-    <SelfCheckTaskState />
-    
-    Erstelle auch für diese Aufgabe eine Lösung.
-    
-    <SelfCheckContent>
-        <Solution id="e92b6f49-396e-48bc-8a6c-4ca94947210d">
-        Lösung zur zweiten Aufgabe 🥳
-        </Solution>
-    </SelfCheckContent>
+:::note[2. Aufgabe]
+<SelfCheckTaskState />
+
+Erstelle auch für diese Aufgabe eine Lösung.
+
+<SelfCheckSolution>
+Lösung zur zweiten Aufgabe 🥳
+</SelfCheckSolution>
+:::
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleTo={SelfCheckStateType.WaitingForSolution}>
+    :::info[Auf Musterlösung warten]
+    Die Lehrperson wird dir die Musterlösung bald freischalten.
     :::
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleTo={SelfCheckStateType.WaitingForSolution}>
-        :::info[Auf Musterlösung warten]
-        Die Lehrperson wird dir die Musterlösung bald freischalten.
-        :::
-    </SelfCheckContent>
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Reviewing}>
-        :::info[Selbstständig korrigieren]
-        Vergleiche deine Lösung nun mit der Musterlösung und korrigiere deine Antwort.
-        :::
-    </SelfCheckContent>
-    
-    <SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Question} visibleTo={SelfCheckStateType.Question}>
-        :::info[Frage?]
-        Wenn du während des Unterrichts eine Frage hast, dann kannst du jederzeit die Lehrperson rufen.
-        :::
-    </SelfCheckContent>
+</SelfCheckContent>
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Reviewing}>
+    :::info[Selbstständig korrigieren]
+    Vergleiche deine Lösung nun mit der Musterlösung und korrigiere deine Antwort.
+    :::
+</SelfCheckContent>
+
+<SelfCheckContent alwaysVisibleForTeacher={false} visibleFrom={SelfCheckStateType.Question} visibleTo={SelfCheckStateType.Question}>
+    :::info[Frage?]
+    Wenn du während des Unterrichts eine Frage hast, dann kannst du jederzeit die Lehrperson rufen.
+    :::
+</SelfCheckContent>
 </SelfCheck>
 </BrowserWindow>

--- a/docs/Komponentengalerie/self-check.md
+++ b/docs/Komponentengalerie/self-check.md
@@ -59,7 +59,7 @@ Die Interpretation der verschiedenen Zustände ist wie folgt vorgesehen:
 | :mdi[checkbox-marked-outline]{.green} Fertig           | Die Bearbeitung der Aufgabe ist abgeschlossen - die eigene Antwort des Schülers ist nun vollständig und korrekt.                                                                                                  |
 
 ## Statusabhängige Sichtbarkeit
-Wenn gewisse Elemente (z.B. die Musterlösung, Hinweise, etc.) nur während bestimmten Zuständen sichtbar sein sollen, eignen sich die Komponenten `<SelfCheckSolution>` (für die Lösung; muss pro `<SelfCheck>` genau einmal vorhanden sein) und `<SelfCheckContent>` (für beliebige Inhalte). Das hier beschriebene Verhalten ist für beide Komponenten identisch.
+Wenn gewisse Elemente (z.B. die Musterlösung, Hinweise, etc.) nur während bestimmten Zuständen sichtbar sein sollen, eignen sich die Komponenten `<SelfCheckSolution>` (für die Lösung; muss pro `<SelfCheck>` genau einmal vorhanden sein) und `<SelfCheckContent>` (für beliebige Inhalte). Das hier beschriebene Verhalten ist für beide Komponenten identisch. Zusätzlich stehen bei der `<SelfCheckSolution>` auch alle Parameter der [`<Solution>`](./solutions.md) zur Verfügung.
 
 Standardmässig zeigen diese Komponenten ihren Inhalt nur in den Zuständen _Warten auf Musterlösung_ und _Korrektur_ an. Dies kann mit den Eigenschaften `visibleFrom` und `visibleTo` angepasst werden. Es stehen dafür je folgende Konstanten zur Verfügung:
 
@@ -82,7 +82,7 @@ Folgendes Beispiel enthält ein Selfcheck-Szenario, in dem die Musterlösung (au
 
 Erstelle auch für diese Aufgabe eine Lösung.
 
-<SelfCheckSolution>
+<SelfCheckSolution title="Lösung zur Aufgabe 3" open>
 Lösung zur zweiten Aufgabe 🥳
 </SelfCheckSolution>
 :::
@@ -114,7 +114,7 @@ Lösung zur zweiten Aufgabe 🥳
 
 Erstelle auch für diese Aufgabe eine Lösung.
 
-<SelfCheckSolution>
+<SelfCheckSolution title="Lösung zur Aufgabe 3" open>
 Lösung zur zweiten Aufgabe 🥳
 </SelfCheckSolution>
 :::

--- a/src/components/documents/SelfCheck/SelfCheckSolution.tsx
+++ b/src/components/documents/SelfCheck/SelfCheckSolution.tsx
@@ -5,11 +5,17 @@ import { SelfCheckStateType } from '@tdev-components/documents/SelfCheck/models'
 import { SelfCheckContext } from '@tdev-components/documents/SelfCheck/shared';
 import SelfCheckContent from '@tdev-components/documents/SelfCheck/SelfCheckContent';
 import Solution from '@tdev-components/documents/Solution';
+import { Access } from '@tdev-api/document';
 
 interface Props extends MetaInit {
     visibleFrom?: SelfCheckStateType;
     visibleTo?: SelfCheckStateType;
     alwaysVisibleForTeacher?: boolean;
+    standalone?: boolean;
+    title?: string;
+    open?: boolean;
+    className?: string;
+    access?: Access;
     children: JSX.Element;
 }
 
@@ -25,7 +31,16 @@ const SelfCheckSolution = observer((props: Props) => {
             visibleTo={props.visibleTo}
             visibleFrom={props.visibleFrom}
         >
-            <Solution id={context.solutionId}>{props.children}</Solution>
+            <Solution
+                id={context.solutionId}
+                standalone={props.standalone}
+                title={props.title}
+                open={props.open}
+                className={props.className}
+                access={props.access}
+            >
+                {props.children}
+            </Solution>
         </SelfCheckContent>
     );
 });

--- a/src/components/documents/SelfCheck/SelfCheckSolution.tsx
+++ b/src/components/documents/SelfCheck/SelfCheckSolution.tsx
@@ -26,19 +26,8 @@ const SelfCheckSolution = observer((props: Props) => {
     }
 
     return (
-        <SelfCheckContent
-            alwaysVisibleForTeacher={props.alwaysVisibleForTeacher}
-            visibleTo={props.visibleTo}
-            visibleFrom={props.visibleFrom}
-        >
-            <Solution
-                id={context.solutionId}
-                standalone={props.standalone}
-                title={props.title}
-                open={props.open}
-                className={props.className}
-                access={props.access}
-            >
+        <SelfCheckContent {...props}>
+            <Solution {...props} id={context.solutionId}>
                 {props.children}
             </Solution>
         </SelfCheckContent>

--- a/src/components/documents/SelfCheck/SelfCheckSolution.tsx
+++ b/src/components/documents/SelfCheck/SelfCheckSolution.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { observer } from 'mobx-react-lite';
+import { MetaInit } from '@tdev-models/documents/TaskState';
+import { SelfCheckStateType } from '@tdev-components/documents/SelfCheck/models';
+import { SelfCheckContext } from '@tdev-components/documents/SelfCheck/shared';
+import SelfCheckContent from '@tdev-components/documents/SelfCheck/SelfCheckContent';
+import Solution from '@tdev-components/documents/Solution';
+
+interface Props extends MetaInit {
+    visibleFrom?: SelfCheckStateType;
+    visibleTo?: SelfCheckStateType;
+    alwaysVisibleForTeacher?: boolean;
+    children: JSX.Element;
+}
+
+const SelfCheckSolution = observer((props: Props) => {
+    const context = React.useContext(SelfCheckContext);
+    if (!context) {
+        throw new Error('SelfCheckSolution must be used within a SelfCheck');
+    }
+
+    return (
+        <SelfCheckContent
+            alwaysVisibleForTeacher={props.alwaysVisibleForTeacher}
+            visibleTo={props.visibleTo}
+            visibleFrom={props.visibleFrom}
+        >
+            <Solution id={context.solutionId}>{props.children}</Solution>
+        </SelfCheckContent>
+    );
+});
+
+export default SelfCheckSolution;


### PR DESCRIPTION
This is a follow-up to #11, adding a new `<SelfCheckSolution>`-component. It wraps a `<Solution>` in a `<SelfCheckContent>`, adding the typical "only show during review" behavior by default. Additionally, it provides the `<Solution>` with the `solutionId` from the surrounding context, thus removing the need for duplicating this ID in the Markdown.

The gallery documentation is updated accordingly.

## TODO

- [x] Expose `<Solution>` props, such as `standalone`