### PR TITLE
Remark media: allow natural aspect ratio for YouTube videos

### DIFF
--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -43,6 +43,7 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
             }
             switch (directive.name) {
                 case LeafDirectiveName.VIDEO:
+                    console.log(style);
                     newNode.name = 'video';
                     if (attributes.autoplay || attributes.autoplay === '') {
                         newNode.attributes.push(toJsxAttribute('autoPlay', ''));
@@ -84,7 +85,7 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                         name: 'iframe',
                         attributes: [
                             toJsxAttribute('width', '100%'),
-                            toJsxAttribute('height', '100%'),
+                            toJsxAttribute('height', style.height || '100%'),
                             toJsxAttribute('src', src),
                             toJsxAttribute('title', 'YouTube video player'),
                             toJsxAttribute('frameBorder', '0'),
@@ -98,9 +99,10 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                         data: {}
                     };
 
+                    console.log(style);
                     newNode.name = 'div';
                     newNode.attributes.push(toJsxAttribute('style', {
-                        width: style.width || '100%',
+                        width: style.maxWidth || '100%',
                         aspectRatio: '16 / 9',
                     }));
                     newNode.children.push(youtubeIframe);

--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -79,19 +79,31 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                     });
                     break;
                 case LeafDirectiveName.YOUTUBE:
-                    newNode.name = 'iframe';
-                    newNode.attributes.push(toJsxAttribute('width', style.width || '100%'));
-                    newNode.attributes.push(toJsxAttribute('height', style.height || '315px'));
-                    newNode.attributes.push(toJsxAttribute('src', src));
-                    newNode.attributes.push(toJsxAttribute('title', 'YouTube video player'));
-                    newNode.attributes.push(toJsxAttribute('frameBorder', '0'));
-                    newNode.attributes.push(
-                        toJsxAttribute(
-                            'allow',
-                            'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
-                        )
-                    );
-                    newNode.attributes.push(toJsxAttribute('allowFullScreen', ''));
+                    const youtubeIframe: MdxJsxFlowElement = {
+                        type: 'mdxJsxFlowElement',
+                        name: 'iframe',
+                        attributes: [
+                            toJsxAttribute('width', '100%'),
+                            toJsxAttribute('height', '100%'),
+                            toJsxAttribute('src', src),
+                            toJsxAttribute('title', 'YouTube video player'),
+                            toJsxAttribute('frameBorder', '0'),
+                            toJsxAttribute('allowFullScreen', ''),
+                            toJsxAttribute(
+                                'allow',
+                                'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture'
+                            )
+                        ],
+                        children: [],
+                        data: {}
+                    };
+
+                    newNode.name = 'div';
+                    newNode.attributes.push(toJsxAttribute('style', {
+                        width: style.width || '100%',
+                        aspectRatio: '16 / 9',
+                    }));
+                    newNode.children.push(youtubeIframe);
                     break;
                 case LeafDirectiveName.CIRCUITVERSE:
                     newNode.name = 'iframe';

--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -43,7 +43,6 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
             }
             switch (directive.name) {
                 case LeafDirectiveName.VIDEO:
-                    console.log(style);
                     newNode.name = 'video';
                     if (attributes.autoplay || attributes.autoplay === '') {
                         newNode.attributes.push(toJsxAttribute('autoPlay', ''));
@@ -99,12 +98,13 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                         data: {}
                     };
 
-                    console.log(style);
                     newNode.name = 'div';
-                    newNode.attributes.push(toJsxAttribute('style', {
-                        width: style.maxWidth || '100%',
-                        aspectRatio: '16 / 9',
-                    }));
+                    newNode.attributes.push(
+                        toJsxAttribute('style', {
+                            width: style.maxWidth || '100%',
+                            aspectRatio: '16 / 9'
+                        })
+                    );
                     newNode.children.push(youtubeIframe);
                     break;
                 case LeafDirectiveName.CIRCUITVERSE:

--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -102,7 +102,7 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                     newNode.attributes.push(
                         toJsxAttribute('style', {
                             width: style.maxWidth || '100%',
-                            aspectRatio: '16 / 9'
+                            aspectRatio: style.height ? undefined : '16 / 9'
                         })
                     );
                     newNode.children.push(youtubeIframe);


### PR DESCRIPTION
YouTube videos currently receive a fixed default height. This change allows them to appear in the player's natural 16/9 aspect ratio instead.

This changes the appearance of all elements that currently use the `::youtube` directive (they will use more vertical real estate). If this effect is undesired, we can also default back to the old behavior (fixed default height of `315px`) and introduce a flag such as `{keepAspectRatio}`.