### PR TITLE
Add Learningapps media directive

### DIFF
--- a/docs/Komponentengalerie/media-shortcuts.md
+++ b/docs/Komponentengalerie/media-shortcuts.md
@@ -10,6 +10,7 @@ Folgende Quellen werden aktuell unterstützt:
 - audio
 - youtube
 - circuitverse
+- learningapps
 
 ```md
 ::video[./assets/yogi-bear.mp4]{width=100% height=200px}
@@ -20,6 +21,8 @@ Folgende Quellen werden aktuell unterstützt:
 ::youtube[https://www.youtube.com/embed/QPZ0pIK_wsc?si=fP8L8fYQ-TYgYwUe]
 
 ::circuitverse[https://circuitverse.org/simulator/embed/rothe-inverter]
+
+::learningapps[https://learningapps.org/7863213]
 ```
 
 <BrowserWindow>
@@ -36,8 +39,9 @@ Folgende Quellen werden aktuell unterstützt:
 <BrowserWindow>
 ::circuitverse[https://circuitverse.org/simulator/embed/rothe-inverter]
 </BrowserWindow>
-
-
+<BrowserWindow>
+::learningapps[https://learningapps.org/7863213]
+</BrowserWindow>
 
 ## Installation
 

--- a/docs/Komponentengalerie/media-shortcuts.md
+++ b/docs/Komponentengalerie/media-shortcuts.md
@@ -43,6 +43,7 @@ Folgende Quellen werden aktuell unterstützt:
 ::learningapps[https://learningapps.org/7863213]
 </BrowserWindow>
 
+
 ## Installation
 
 :::info[Code]

--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -10,7 +10,7 @@ enum LeafDirectiveName {
     AUDIO = 'audio',
     YOUTUBE = 'youtube',
     CIRCUITVERSE = 'circuitverse',
-    LEARNINGAPPS = 'learningapps',
+    LEARNINGAPPS = 'learningapps'
 }
 const DirectiveNames = Object.values(LeafDirectiveName) as string[];
 
@@ -121,14 +121,13 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                     newNode.attributes.push(toJsxAttribute('allowFullScreen', ''));
                     break;
                 case LeafDirectiveName.LEARNINGAPPS:
-                    // <iframe src="https://learningapps.org/watch?app=7863213" style="border:0px;width:100%;height:500px" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"></iframe>
-                    // const transformedSrc = 'https://learningapps.org/7863213';
-                    const transformedSrc = 'https://learningapps.org/watch?app=7863213';
+                    const appId = new URL(src).pathname.split('/')[1];
+                    const transformedSrc = `https://learningapps.org/watch?app=${appId}`;
                     newNode.name = 'iframe';
                     newNode.attributes.push(toJsxAttribute('width', style.width || '100%'));
                     newNode.attributes.push(toJsxAttribute('height', style.height || '500px'));
                     newNode.attributes.push(toJsxAttribute('src', transformedSrc));
-                    newNode.attributes.push(toJsxAttribute('title', 'Circuit Verse'));
+                    newNode.attributes.push(toJsxAttribute('title', 'Learningapps'));
                     newNode.attributes.push(toJsxAttribute('frameBorder', '0'));
                     newNode.attributes.push(toJsxAttribute('scrolling', 'no'));
                     newNode.attributes.push(toJsxAttribute('webkitallowfullscreen', ''));

--- a/src/plugins/remark-media/plugin.ts
+++ b/src/plugins/remark-media/plugin.ts
@@ -9,7 +9,8 @@ enum LeafDirectiveName {
     VIDEO = 'video',
     AUDIO = 'audio',
     YOUTUBE = 'youtube',
-    CIRCUITVERSE = 'circuitverse'
+    CIRCUITVERSE = 'circuitverse',
+    LEARNINGAPPS = 'learningapps',
 }
 const DirectiveNames = Object.values(LeafDirectiveName) as string[];
 
@@ -112,6 +113,21 @@ const plugin: Plugin = function plugin(this: Processor, optionsInput?: {}): Tran
                     newNode.attributes.push(toJsxAttribute('width', style.width || '100%'));
                     newNode.attributes.push(toJsxAttribute('height', style.height || '315px'));
                     newNode.attributes.push(toJsxAttribute('src', src));
+                    newNode.attributes.push(toJsxAttribute('title', 'Circuit Verse'));
+                    newNode.attributes.push(toJsxAttribute('frameBorder', '0'));
+                    newNode.attributes.push(toJsxAttribute('scrolling', 'no'));
+                    newNode.attributes.push(toJsxAttribute('webkitallowfullscreen', ''));
+                    newNode.attributes.push(toJsxAttribute('mozAllowFullScreen', ''));
+                    newNode.attributes.push(toJsxAttribute('allowFullScreen', ''));
+                    break;
+                case LeafDirectiveName.LEARNINGAPPS:
+                    // <iframe src="https://learningapps.org/watch?app=7863213" style="border:0px;width:100%;height:500px" allowfullscreen="true" webkitallowfullscreen="true" mozallowfullscreen="true"></iframe>
+                    // const transformedSrc = 'https://learningapps.org/7863213';
+                    const transformedSrc = 'https://learningapps.org/watch?app=7863213';
+                    newNode.name = 'iframe';
+                    newNode.attributes.push(toJsxAttribute('width', style.width || '100%'));
+                    newNode.attributes.push(toJsxAttribute('height', style.height || '500px'));
+                    newNode.attributes.push(toJsxAttribute('src', transformedSrc));
                     newNode.attributes.push(toJsxAttribute('title', 'Circuit Verse'));
                     newNode.attributes.push(toJsxAttribute('frameBorder', '0'));
                     newNode.attributes.push(toJsxAttribute('scrolling', 'no'));


### PR DESCRIPTION
Add a new `learningapps` leaf directive to the `remark-media` plugin.

The default height is set to `500px` here because this is what Learningapps suggests in their embed link, and it results in a more sensible aspect ration. However, we can also change this to `315px` as is the case for most other iframes created by this pluign (users can always open the app in full screen).