### PR TITLE
Cleanup <Restricted>

### DIFF
--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -9,6 +9,7 @@ import { Delta } from 'quill/core';
 import Solution from '../models/documents/Solution';
 import Directory from '../models/documents/FileSystem/Directory';
 import File from '../models/documents/FileSystem/File';
+import Restricted from '@tdev-models/documents/Restricted';
 
 export enum Access {
     RO_DocumentRoot = 'RO_DocumentRoot',
@@ -30,7 +31,8 @@ export enum DocumentType {
     QuillV2 = 'quill_v2',
     Solution = 'solution',
     Dir = 'dir',
-    File = 'file'
+    File = 'file',
+    Restricted = 'restricted'
 }
 export interface ScriptData {
     code: string;
@@ -51,6 +53,10 @@ export interface QuillV2Data {
 }
 
 export interface SolutionData {
+    /** no content needed */
+}
+
+export interface RestrictedData {
     /** no content needed */
 }
 
@@ -87,6 +93,7 @@ export interface TypeDataMapping {
     [DocumentType.Solution]: SolutionData;
     [DocumentType.Dir]: DirData;
     [DocumentType.File]: FileData;
+    [DocumentType.Restricted]: RestrictedData;
     // Add more mappings as needed
 }
 
@@ -99,6 +106,7 @@ export interface TypeModelMapping {
     [DocumentType.Solution]: Solution;
     [DocumentType.Dir]: Directory;
     [DocumentType.File]: File;
+    [DocumentType.Restricted]: Restricted;
     /**
      * Add more mappings as needed
      * TODO: implement the mapping in DocumentRoot.ts

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -36,7 +36,9 @@ const Restricted = observer((props: Props) => {
             )}
             <div className={styles.adminControls}>
                 {userStore.current?.isAdmin && <PermissionsPanel documentRootId={docRoot.id} />}
-                {NoneAccess.has(docRoot.permission) && <span className="badge badge--secondary">Hidden</span>}
+                {userStore.current?.isAdmin && NoneAccess.has(docRoot.permission) && (
+                    <span className="badge badge--secondary">Hidden</span>
+                )}
             </div>
         </div>
     );

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
 import Loader from '@tdev-components/Loader';
-import { MetaInit, ModelMeta } from '@tdev-models/documents/Solution';
+import { MetaInit, ModelMeta } from '@tdev-models/documents/Restricted';
 import { useDocumentRoot } from '@tdev-hooks/useDocumentRoot';
 import { Access } from '@tdev-api/document';
 import { useStore } from '@tdev-hooks/useStore';

--- a/src/models/documents/Restricted.ts
+++ b/src/models/documents/Restricted.ts
@@ -1,0 +1,51 @@
+import { action, computed } from 'mobx';
+import iDocument, { Source } from '@tdev-models/iDocument';
+import { DocumentType, Document as DocumentProps, TypeDataMapping, Access } from '@tdev-api/document';
+import DocumentStore from '@tdev-stores/DocumentStore';
+import { TypeMeta } from '@tdev-models/DocumentRoot';
+
+export interface MetaInit {
+    readonly?: boolean;
+}
+
+export class ModelMeta extends TypeMeta<DocumentType.Restricted> {
+    readonly type = DocumentType.Restricted;
+
+    constructor(props: Partial<MetaInit>) {
+        super(DocumentType.Restricted, props.readonly ? Access.RO_User : undefined);
+    }
+
+    get defaultData(): TypeDataMapping[DocumentType.Restricted] {
+        return {};
+    }
+}
+
+class Restricted extends iDocument<DocumentType.Restricted> {
+    constructor(props: DocumentProps<DocumentType.Restricted>, store: DocumentStore) {
+        super(props, store);
+    }
+
+    @action
+    setData(_: TypeDataMapping[DocumentType.Restricted], from: Source, updatedAt?: Date): void {
+        if (from === Source.LOCAL) {
+            this.save();
+        }
+        if (updatedAt) {
+            this.updatedAt = new Date(updatedAt);
+        }
+    }
+
+    get data(): TypeDataMapping[DocumentType.Restricted] {
+        return {};
+    }
+
+    @computed
+    get meta(): ModelMeta {
+        if (this.root?.type === DocumentType.Restricted) {
+            return this.root.meta as ModelMeta;
+        }
+        return new ModelMeta({});
+    }
+}
+
+export default Restricted;


### PR DESCRIPTION
- Create and use a custom document model for the `<Restricted>` item, just to keep things clean.
- Don't show the `Hidden` badge to non-admins (the idea of this component is that a non-authorized user simply doesn't see anything).