### PR TITLE
Feature/link annotation plugin

### DIFF
--- a/docs/Komponentengalerie/link-annotation.mdx
+++ b/docs/Komponentengalerie/link-annotation.mdx
@@ -23,7 +23,7 @@ Damit dies nicht in jedem Link händisch hinzugefügt werden muss, kann dies mit
 
 :::info[`docusaurus.config.ts]
 
-```ts {1,8,11,14}
+```ts
 import linkAnnotationPlugin from './src/plugins/remark-link-annotation/plugin';
 
 const REMARK_PLUGINS = [

--- a/docs/Komponentengalerie/link-annotation.mdx
+++ b/docs/Komponentengalerie/link-annotation.mdx
@@ -1,16 +1,17 @@
 ---
 page_id: c9c9f754-5ec5-487b-bdfd-a7047adc0e48
+tags: [remark]
 ---
 
 # Links Annotieren
 
 Oft ist es hilfreich, Links mit einem zusätzlichen Symbol hervorzuheben:
 Statt
-: [Link](#)
+: <a href="#">Link</a>
 mit Präfix
 : [👉 Link](#)
 mit Postfix
-: [Link 🔗](#)
+: <a href="#">Link 🔗</a>
 
 Damit dies nicht in jedem Link händisch hinzugefügt werden muss, kann dies mit einem Remark-Plugin hinzugefügt werden.
 

--- a/docs/Komponentengalerie/link-annotation.mdx
+++ b/docs/Komponentengalerie/link-annotation.mdx
@@ -1,0 +1,44 @@
+---
+page_id: c9c9f754-5ec5-487b-bdfd-a7047adc0e48
+---
+
+# Links Annotieren
+
+Oft ist es hilfreich, Links mit einem zusätzlichen Symbol hervorzuheben:
+Statt
+: [Link](#)
+mit Präfix
+: [👉 Link](#)
+mit Postfix
+: [Link 🔗](#)
+
+Damit dies nicht in jedem Link händisch hinzugefügt werden muss, kann dies mit einem Remark-Plugin hinzugefügt werden.
+
+
+## Installation
+
+:::info[Code]
+- `src/plugins/remark-link-annotation`
+:::
+
+:::info[`docusaurus.config.ts]
+
+```ts {1,8,11,14}
+import linkAnnotationPlugin from './src/plugins/remark-link-annotation/plugin';
+
+const REMARK_PLUGINS = [
+    /* ... */
+    [
+        linkAnnotationPlugin,
+        {
+            prefix: '👉',
+            postfix: null
+        }
+    ]
+];
+```
+:::
+
+:::tip[Keine doppelten Symbole]
+Ist ein Link bereits händisch annotiert worden, so wird er vom Plugin nicht ein weiteres Mal mit demselben Symbol annotiert.
+:::

--- a/docs/Komponentengalerie/task-state.md
+++ b/docs/Komponentengalerie/task-state.md
@@ -89,7 +89,7 @@ TaskState kann nicht verändert werden, wenn `readonly` gesetzt wurde.
 
 
 :::info[Gleiche ID]
-Wenn [👉 oberhalb](#zustände-selber-setzen) der Zustand verändert wird, wird er auch hier verändert.
+Wenn [oberhalb](#zustände-selber-setzen) der Zustand verändert wird, wird er auch hier verändert.
 :::
 
 ### In einer Admonition

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -13,6 +13,7 @@ import rehypeKatex from 'rehype-katex';
 import defboxPlugin from './src/plugins/remark-code-defbox/plugin';
 import flexCardsPlugin from './src/plugins/remark-flex-cards/plugin';
 import imagePlugin from './src/plugins/remark-images/plugin';
+import linkAnnotationPlugin from './src/plugins/remark-link-annotation/plugin';
 import mediaPlugin from './src/plugins/remark-media/plugin';
 import detailsPlugin from './src/plugins/remark-details/plugin';
 import themeCodeEditor from './src/plugins/theme-code-editor'
@@ -66,6 +67,13 @@ const REMARK_PLUGINS = [
     {
       componentsToEnumerate: ['Answer', 'TaskState', 'SelfCheckTaskState'],
     }
+  ],
+  [
+      linkAnnotationPlugin,
+      {
+          prefix: '👉',
+          postfix: null
+      }
   ]
 ];
 const REHYPE_PLUGINS = [

--- a/src/plugins/remark-link-annotation/plugin.ts
+++ b/src/plugins/remark-link-annotation/plugin.ts
@@ -1,0 +1,41 @@
+import { visit, CONTINUE, SKIP } from 'unist-util-visit';
+import type { Plugin, Processor, Transformer } from 'unified';
+import type { MdxJsxTextElement } from 'mdast-util-mdx';
+import { Link, Parent, Text } from 'mdast';
+const plugin: Plugin = function plugin(
+    this: Processor,
+    optionsInput?: {
+        prefix?: string | null;
+        postfix?: string | null;
+    }
+): Transformer {
+    const options = optionsInput || {};
+    const prefix = options.prefix === undefined ? '👉' : options.prefix?.trim();
+    const postfix = options.postfix?.trim() || null;
+
+    return (tree) => {
+        visit(tree, 'link', (node: Link, index, parent) => {
+            if (prefix) {
+                if (node.children.length < 1 || node.children[0].type !== 'text') {
+                    node.children.unshift({ type: 'text', value: `${prefix} ` } as Text);
+                } else if (node.children[0].type === 'text') {
+                    if (!node.children[0].value.startsWith(prefix)) {
+                        node.children[0].value = `${prefix} ${node.children[0].value}`;
+                    }
+                }
+            }
+            if (postfix) {
+                const lastLinkPos = node.children.length - 1;
+                if (lastLinkPos < 0 || node.children[lastLinkPos].type !== 'text') {
+                    node.children.push({ type: 'text', value: ` ${postfix}` } as Text);
+                } else if (node.children[lastLinkPos].type === 'text') {
+                    if (!node.children[lastLinkPos].value.endsWith(postfix)) {
+                        node.children[lastLinkPos].value = `${node.children[lastLinkPos].value} ${postfix}`;
+                    }
+                }
+            }
+        });
+    };
+};
+
+export default plugin;

--- a/src/plugins/remark-link-annotation/tests/plugin.test.ts
+++ b/src/plugins/remark-link-annotation/tests/plugin.test.ts
@@ -1,0 +1,73 @@
+import { remark } from 'remark';
+import remarkMdx from 'remark-mdx';
+import remarkDirective from 'remark-directive';
+import { describe, expect, it } from 'vitest';
+
+const process = async (content: string, config: { prefix?: string | null; postfix?: string | null } = {}) => {
+    const { default: plugin } = await import('../plugin');
+    const result = await remark()
+        .use(remarkMdx)
+        .use(remarkDirective)
+        .use(plugin, config as any)
+        .process(content);
+
+    return result.value;
+};
+
+describe('#link annotation', () => {
+    it("does nothing if there's no link", async () => {
+        const input = `# Heading
+
+Some content
+`;
+        const result = await process(input);
+        expect(result).toBe(input);
+    });
+    it('can convert links', async () => {
+        const input = `# Details element example
+        Hello [example](https://example.org) world!
+        `;
+        const result = await process(input);
+        expect(result).toMatchInlineSnapshot(`
+        "# Details element example
+
+        Hello [👉 example](https://example.org) world!
+        "`);
+    });
+
+    it('does not append the prefix, if it is already there', async () => {
+        const input = `# Details element example
+        Hello [👉 example](https://example.org) world!
+        `;
+        const result = await process(input);
+        expect(result).toMatchInlineSnapshot(`
+        "# Details element example
+
+        Hello [👉 example](https://example.org) world!
+        "`);
+    });
+
+    it('can configure the prefix', async () => {
+        const input = `# Details element example
+        Hello [example](https://example.org) world!
+        `;
+        const result = await process(input, { prefix: '🔗' });
+        expect(result).toMatchInlineSnapshot(`
+        "# Details element example
+
+        Hello [🔗 example](https://example.org) world!
+        "`);
+    });
+
+    it('can set a postfix', async () => {
+        const input = `# Details element example
+        Hello [example](https://example.org) world!
+        `;
+        const result = await process(input, { prefix: null, postfix: '🔗' });
+        expect(result).toMatchInlineSnapshot(`
+        "# Details element example
+
+        Hello [example 🔗](https://example.org) world!
+        "`);
+    });
+});


### PR DESCRIPTION
# Link Annotation Plugin

This remark plugin enables to pre- or postfix links with a Symbol to make clickable links more visible. 

Instead of [Link](#), it can add a prefix  [👉 Link](#), a postfix [Link 🔗](#) or even both...

If the pre/postfix is already present, it will not be added again.
> [!NOTE]  
> The plugin is not yet activated for this repo - should we?

## Try it out

https://deploy-preview-23--teaching-dev.netlify.app/docs/Komponentengalerie/link-annotation