### PR TITLE
polish: make figcaptions commentable

### DIFF
--- a/docs/Komponentengalerie/mdx-comments/index.mdx
+++ b/docs/Komponentengalerie/mdx-comments/index.mdx
@@ -110,7 +110,7 @@ const REMARK_PLUGINS = [
   [
     commentPlugin,
     {
-      commentableJsxFlowElements: ['dd'],
+      commentableJsxFlowElements: ['dd', 'DefHeading', 'figcaption'],
       ignoreJsxFlowElements: ['summary', 'dt'],
       ignoreCodeBlocksWithMeta: /live_py/
     }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -74,7 +74,7 @@ const REMARK_PLUGINS = [
   [
     commentPlugin,
     {
-      commentableJsxFlowElements: ['dd', 'DefHeading'],
+      commentableJsxFlowElements: ['dd', 'DefHeading', 'figcaption'],
       ignoreJsxFlowElements: ['summary', 'dt'],
       ignoreCodeBlocksWithMeta: /live_py/
     }

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -74,7 +74,7 @@ const REMARK_PLUGINS = [
   [
     commentPlugin,
     {
-      commentableJsxFlowElements: ['dd', 'DefHeading', 'figcaption'],
+      commentableJsxFlowElements: ['dd', 'DefHeading', 'figcaption', 'String'],
       ignoreJsxFlowElements: ['summary', 'dt'],
       ignoreCodeBlocksWithMeta: /live_py/
     }

--- a/src/components/Figure/styles.module.scss
+++ b/src/components/Figure/styles.module.scss
@@ -12,7 +12,7 @@
         flex-wrap: wrap;
         gap: 0.2em;
         line-height: 1em;
-        margin-top: 0.5em;
+        margin-top: -0.4em;
         margin-bottom: 0.5em;
 
         &:global(.inline) {
@@ -23,6 +23,11 @@
             opacity: 50%;
 
             &:hover {
+                opacity: 100%;
+            }
+            &:has(+ :global(.comment-wrapper.open)) {
+                position: unset;
+                padding: 0;
                 opacity: 100%;
             }
         }

--- a/src/components/documents/MdxComment/Comment/index.tsx
+++ b/src/components/documents/MdxComment/Comment/index.tsx
@@ -27,10 +27,12 @@ const Comment = observer((props: Props) => {
         <>
             <div
                 className={clsx(
+                    'comment-wrapper',
                     sharedStyles.wrapper,
                     sharedStyles.colorized,
                     sharedStyles.active,
                     comment.isOpen && sharedStyles.open,
+                    comment.isOpen && 'open',
                     sharedStyles[comment.color],
                     styles.iconWrapper
                 )}


### PR DESCRIPTION
- make the whole figcaption commentable and prevent partial inline-comments
- ensure inlined figcaptions will be outlined when a comment is open
- make `<String />` Components commentable too