### PR TITLE
fix: register `Restricted` in DocumentTypes and add initializer

### DIFF
--- a/src/api/document.ts
+++ b/src/api/document.ts
@@ -136,7 +136,8 @@ export type DocumentTypes =
     | Solution
     | Directory
     | File
-    | MdxComment;
+    | MdxComment
+    | Restricted;
 
 export interface Document<Type extends DocumentType> {
     id: string;

--- a/src/stores/DocumentStore.ts
+++ b/src/stores/DocumentStore.ts
@@ -27,6 +27,7 @@ import { RWAccess } from '@tdev-models/helpers/accessPolicy';
 import Directory from '@tdev-models/documents/FileSystem/Directory';
 import File from '@tdev-models/documents/FileSystem/File';
 import MdxComment from '@tdev-models/documents/MdxComment';
+import Restricted from '@tdev-models/documents/Restricted';
 
 export function CreateDocumentModel<T extends DocumentType>(
     data: DocumentProps<T>,
@@ -52,6 +53,8 @@ export function CreateDocumentModel(data: DocumentProps<DocumentType>, store: Do
             return new File(data as DocumentProps<DocumentType.File>, store);
         case DocumentType.MdxComment:
             return new MdxComment(data as DocumentProps<DocumentType.MdxComment>, store);
+        case DocumentType.Restricted:
+            return new Restricted(data as DocumentProps<DocumentType.Restricted>, store);
     }
 }
 class DocumentStore extends iStore<`delete-${string}`> {


### PR DESCRIPTION
Each document model must have a initializer in `DocumentStore.ts#CreateDocumentModel`. This was missing for `DocumentType.Restricted`.
