### PR TITLE
Rework CMS Text wrapper

### DIFF
--- a/docs/Komponentengalerie/cms-text.mdx
+++ b/docs/Komponentengalerie/cms-text.mdx
@@ -91,8 +91,10 @@ Ist einer der in `entries` aufgeführten CMS-Texte nicht verfügbar, wird der ge
     </WithCmsText>
 </BrowserWindow>
 
-### Anwendungsbeispiel
-Diese Funktion kann beispielsweise dann nützlich sein, wenn ein Eintrag in einer `<DefinitionList>` nur angezeigt werden soll, sofern für den `<dd>`-Wert ein CMS-Text zur Verfügung steht.
+### Anwendungsbeispiele
+Im folgenden Beispiel wird die gesamte `<DefinitionList>` nur dann angezeigt, wenn der Eintrag für die DocumentRoot-ID `21535ea1-47d9-4521-a7fa-392f06d08f0a` vorhanden ist. In dem Fall steht der entsprechende CMS-Text innerhalb der `<WithCmsText>`-Klammer unter dem Namen `demo` zur Verfügung.
+
+Zusätzlich wird ein weiterer CMS-Text mit der ID `2c0c085d-388a-48cd-9871-975bab0ffda3` verwendet. Wenn dort das entsprechende Dokument fehlt, bleibt der Eintrag einfach leer.
 
 ```md
 <WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
@@ -123,6 +125,8 @@ Diese Funktion kann beispielsweise dann nützlich sein, wenn ein Eintrag in eine
         </DefinitionList>
     </WithCmsText>
 </BrowserWindow>
+
+Bei mehreren Einträgen zeigt die `<WithCmsText>`-Klammer ihren Inhalt nur dann an, wenn alle entsprechenden Documents vorhanden sind:
 
 ```md
 <WithCmsText entries={{
@@ -157,6 +161,8 @@ Diese Funktion kann beispielsweise dann nützlich sein, wenn ein Eintrag in eine
         </DefinitionList>
     </WithCmsText>
 </BrowserWindow>
+
+`<WithCmsText>`-Klammern können auch verschachtelt genutzt werden:
 
 ```md
 <WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>

--- a/docs/Komponentengalerie/cms-text.mdx
+++ b/docs/Komponentengalerie/cms-text.mdx
@@ -21,11 +21,24 @@ export const DocumentCreator = observer(() => {
 });
 
 <DocumentCreator />
-:::info[Erstellung von Documents]
+::::info[Erstellung von Documents]
 Im Gegensatz zu vielen anderen Komponenten erstellen die Komponenten rund um CMS-Text bewusst **nicht** automatisch ein Document, wenn keins vorhanden ist.
 
 Diese Gallery-Page ist so aufgesetzt, dass für die DocumentRoot-ID `21535ea1-47d9-4521-a7fa-392f06d08f0a` automatisch ein CmsText-Document erzeugt wird. Für die ID `2c0c085d-388a-48cd-9871-975bab0ffda3` wird kein Document erstellt.
+
+:::details[Implementierung]
+Das Dokument wird hier im `.mdx` wie folgt erzeugt:
+```tsx
+export const DocumentCreator = observer(() => {
+    useFirstMainDocument('21535ea1-47d9-4521-a7fa-392f06d08f0a', new CmsTextMeta({
+        default: 'CMS-Text aus der Datenbank 📚'
+    }));
+    return <></>;
+});
+<DocumentCreator />
+```
 :::
+::::
 
 Soll ein bestimmter Wert nicht fix im Markdown hinterlegt, sondern aus der Datenbank geladen werden, eignet sich die Komponente `<CmsText>`.
 

--- a/docs/Komponentengalerie/cms-text.mdx
+++ b/docs/Komponentengalerie/cms-text.mdx
@@ -146,9 +146,12 @@ Bei mehreren Einträgen zeigt die `<WithCmsText>`-Klammer ihren Inhalt nur dann 
 ```
 
 <BrowserWindow>
-    <WithCmsText entries={{
-            a: "21535ea1-47d9-4521-a7fa-392f06d08f0a",
-            b: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+    <WithCmsText
+        entries={{
+            a: '21535ea1-47d9-4521-a7fa-392f06d08f0a',
+            b: '2c0c085d-388a-48cd-9871-975bab0ffda3'
+        }}
+    >
         <DefinitionList>
             <dt>Hallo</dt>
             <dd>Das ist der erste Eintrag.</dd>

--- a/docs/Komponentengalerie/cms-text.mdx
+++ b/docs/Komponentengalerie/cms-text.mdx
@@ -37,7 +37,7 @@ Der Text "<CmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a"/>" wurde aus der Da
 ```
 
 <BrowserWindow>
-Der Text "<CmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a"/>" wurde aus der Datenbank geladen.
+    Der Text "<CmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a"/>" wurde aus der Datenbank geladen.
 </BrowserWindow>
 
 Besitzt der aktuelle User kein Document für die angegebene DocumentRoot-ID, dann bleibt der Text leer:
@@ -47,86 +47,134 @@ Der Text "<CmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3"/>" wurde aus der Da
 ```
 
 <BrowserWindow>
-Der Text "<CmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3"/>" wurde aus der Datenbank geladen.
+    Der Text "<CmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3"/>" wurde aus der Datenbank geladen.
 </BrowserWindow>
 
 ## Einfluss auf umliegende Elemente
 In vielen Fällen kann es nützlich sein, auch umliegende Elemente nur dann anzuzeigen, wenn ein bestimmter CMS-Text verfügbar ist. Dazu kann die Komponente `<WithCmsText>` verwendet werden.
+
 ```md
-<WithCmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a">Der Text "<CmsText />" wurde aus der Datenbank geladen.</WithCmsText>
+<WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
+    Der Text "<CmsText name="demo" />" wurde aus der Datenbank geladen.
+</WithCmsText>
 ```
 
 <BrowserWindow>
-    <WithCmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a">Der Text "<CmsText />" wurde aus der Datenbank geladen.</WithCmsText>
+    <WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
+        Der Text "<CmsText name="demo" />" wurde aus der Datenbank geladen.
+    </WithCmsText>
 </BrowserWindow>
 
-Ist der entsprechende CMS-Text nicht verfügbar, wird der gesamte Inhalt dieser Klammer ausgeblendet:
-
+Ist einer der in `entries` aufgeführten CMS-Texte nicht verfügbar, wird der gesamte Inhalt dieser Klammer ausgeblendet:
 ```md
-<WithCmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3">Der Text "<CmsText />" wurde aus der Datenbank geladen.</WithCmsText>
+<WithCmsText entries={{demo: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+    Der Text "<CmsText name="demo" />" wurde aus der Datenbank geladen.
+</WithCmsText>
 ```
 
 <BrowserWindow>
-    <WithCmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3">Der Text "<CmsText />" wurde aus der Datenbank geladen.</WithCmsText>
+    <WithCmsText entries={{text: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+        Der Text "<CmsText name="demo" />" wurde aus der Datenbank geladen.
+    </WithCmsText>
 </BrowserWindow>
 
 ### Anwendungsbeispiel
 Diese Funktion kann beispielsweise dann nützlich sein, wenn ein Eintrag in einer `<DefinitionList>` nur angezeigt werden soll, sofern für den `<dd>`-Wert ein CMS-Text zur Verfügung steht.
 
 ```md
-<BrowserWindow>
+<WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
     <DefinitionList>
         <dt>Hallo</dt>
         <dd>Das ist der erste Eintrag.</dd>
         <dt>Welt</dt>
         <dd>Das ist der zweite Eintrag.</dd>
-        <WithCmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a">
-            <dt>CMS-Eintrag</dt>
-            <dd><CmsText /></dd>
-        </WithCmsText>
+        <dt>CMS-Eintrag</dt>
+        <dd><CmsText name="demo" /></dd>
+        <dt>Anderer CMS-Eintrag</dt>
+        <dt><CmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3" /></dt>
     </DefinitionList>
-</BrowserWindow>
+</WithCmsText>
 ```
 
 <BrowserWindow>
-    <DefinitionList>
-        <dt>Hallo</dt>
-        <dd>Das ist der erste Eintrag.</dd>
-        <dt>Welt</dt>
-        <dd>Das ist der zweite Eintrag.</dd>
-        <WithCmsText id="21535ea1-47d9-4521-a7fa-392f06d08f0a">
+    <WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
+        <DefinitionList>
+            <dt>Hallo</dt>
+            <dd>Das ist der erste Eintrag.</dd>
+            <dt>Welt</dt>
+            <dd>Das ist der zweite Eintrag.</dd>
             <dt>CMS-Eintrag</dt>
-            <dd><CmsText /></dd>
-        </WithCmsText>
-    </DefinitionList>
+            <dd><CmsText name="demo" /></dd>
+            <dt>Anderer CMS-Eintrag</dt>
+            <dt><CmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3" /></dt>
+        </DefinitionList>
+    </WithCmsText>
 </BrowserWindow>
-
-Ist der entsprechende CMS-Text nicht verfügbar, wird der gesamte Eintrag nicht angezeigt:
 
 ```md
-<BrowserWindow>
+<WithCmsText entries={{
+        a: "21535ea1-47d9-4521-a7fa-392f06d08f0a",
+        b: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
     <DefinitionList>
         <dt>Hallo</dt>
         <dd>Das ist der erste Eintrag.</dd>
         <dt>Welt</dt>
         <dd>Das ist der zweite Eintrag.</dd>
-        <WithCmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3">
-            <dt>CMS-Eintrag</dt>
-            <dd><CmsText /></dd>
-        </WithCmsText>
+        <dt>CMS-Eintrag</dt>
+        <dd><CmsText name="a" /></dd>
+        <dt>Anderer CMS-Eintrag</dt>
+        <dt><CmsText name="b" /></dt>
     </DefinitionList>
-</BrowserWindow>
+</WithCmsText>
 ```
 
 <BrowserWindow>
+    <WithCmsText entries={{
+            a: "21535ea1-47d9-4521-a7fa-392f06d08f0a",
+            b: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+        <DefinitionList>
+            <dt>Hallo</dt>
+            <dd>Das ist der erste Eintrag.</dd>
+            <dt>Welt</dt>
+            <dd>Das ist der zweite Eintrag.</dd>
+            <dt>CMS-Eintrag</dt>
+            <dd><CmsText name="a" /></dd>
+            <dt>Anderer CMS-Eintrag</dt>
+            <dt><CmsText name="b" /></dt>
+        </DefinitionList>
+    </WithCmsText>
+</BrowserWindow>
+
+```md
+<WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
     <DefinitionList>
         <dt>Hallo</dt>
         <dd>Das ist der erste Eintrag.</dd>
         <dt>Welt</dt>
         <dd>Das ist der zweite Eintrag.</dd>
-        <WithCmsText id="2c0c085d-388a-48cd-9871-975bab0ffda3">
-            <dt>CMS-Eintrag</dt>
-            <dd><CmsText /></dd>
+        <dt>CMS-Eintrag</dt>
+        <dd><CmsText name="demo" /></dd>
+        <WithCmsText entries={{demo: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+            <dt>Anderer CMS-Eintrag</dt>
+            <dt><CmsText id="demo" /></dt>
         </WithCmsText>
     </DefinitionList>
+</WithCmsText>
+```
+
+<BrowserWindow>
+    <WithCmsText entries={{demo: "21535ea1-47d9-4521-a7fa-392f06d08f0a"}}>
+        <DefinitionList>
+            <dt>Hallo</dt>
+            <dd>Das ist der erste Eintrag.</dd>
+            <dt>Welt</dt>
+            <dd>Das ist der zweite Eintrag.</dd>
+            <dt>CMS-Eintrag</dt>
+            <dd><CmsText name="demo" /></dd>
+            <WithCmsText entries={{demo: "2c0c085d-388a-48cd-9871-975bab0ffda3"}}>
+                <dt>Anderer CMS-Eintrag</dt>
+                <dt><CmsText id="demo" /></dt>
+            </WithCmsText>
+        </DefinitionList>
+    </WithCmsText>
 </BrowserWindow>

--- a/src/components/documents/CmsText/WithCmsText.tsx
+++ b/src/components/documents/CmsText/WithCmsText.tsx
@@ -2,15 +2,17 @@ import { CmsTextContext, useFirstCmsTextDocumentIfExists } from '@tdev-component
 import { observer } from 'mobx-react-lite';
 
 interface Props {
-    id: string;
+    entries: { [key: string]: string };
     children?: React.ReactNode;
 }
 
-const WithCmsText = observer(({ id, children }: Props) => {
-    const doc = useFirstCmsTextDocumentIfExists(id);
+const WithCmsText = observer(({ entries, children }: Props) => {
 
-    return doc ? (
-        <CmsTextContext.Provider value={{ cmsText: doc.text }}>{children}</CmsTextContext.Provider>
+    const allDocumentsAvailable = Object.values(entries)
+        .every(documentRootId => !!useFirstCmsTextDocumentIfExists(documentRootId));
+
+    return allDocumentsAvailable ? (
+        <CmsTextContext.Provider value={{ entries }}>{children}</CmsTextContext.Provider>
     ) : (
         <></>
     );

--- a/src/components/documents/CmsText/WithCmsText.tsx
+++ b/src/components/documents/CmsText/WithCmsText.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 const WithCmsText = observer(({ entries, children }: Props) => {
-
-    const allDocumentsAvailable = Object.values(entries)
-        .every(documentRootId => !!useFirstCmsTextDocumentIfExists(documentRootId));
+    const allDocumentsAvailable = Object.values(entries).every(
+        (documentRootId) => !!useFirstCmsTextDocumentIfExists(documentRootId)
+    );
 
     return allDocumentsAvailable ? (
         <CmsTextContext.Provider value={{ entries }}>{children}</CmsTextContext.Provider>

--- a/src/components/documents/CmsText/WithCmsText.tsx
+++ b/src/components/documents/CmsText/WithCmsText.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 const WithCmsText = observer(({ entries, children }: Props) => {
-    const allDocumentsAvailable = Object.values(entries).every(
+    const allDocumentsAvailable = Object.values(entries).map(
         (documentRootId) => !!useFirstCmsTextDocumentIfExists(documentRootId)
-    );
+    ).every(Boolean);
 
     return allDocumentsAvailable ? (
         <CmsTextContext.Provider value={{ entries }}>{children}</CmsTextContext.Provider>

--- a/src/components/documents/CmsText/WithCmsText.tsx
+++ b/src/components/documents/CmsText/WithCmsText.tsx
@@ -7,9 +7,9 @@ interface Props {
 }
 
 const WithCmsText = observer(({ entries, children }: Props) => {
-    const allDocumentsAvailable = Object.values(entries).map(
-        (documentRootId) => !!useFirstCmsTextDocumentIfExists(documentRootId)
-    ).every(Boolean);
+    const allDocumentsAvailable = Object.values(entries)
+        .map((documentRootId) => !!useFirstCmsTextDocumentIfExists(documentRootId))
+        .every(Boolean);
 
     return allDocumentsAvailable ? (
         <CmsTextContext.Provider value={{ entries }}>{children}</CmsTextContext.Provider>

--- a/src/components/documents/CmsText/index.tsx
+++ b/src/components/documents/CmsText/index.tsx
@@ -4,20 +4,13 @@ import React from 'react';
 
 interface Props {
     id?: string;
+    name?: string;
 }
 
-const CmsText = observer(({ id }: Props) => {
-    const context = React.useContext(CmsTextContext);
+const CmsText = observer(({ id, name }: Props) => {
 
-    let cmsText: string | undefined;
-
-    if (context && !id) {
-        cmsText = context.cmsText;
-    } else if (!context && id) {
-        cmsText = useFirstCmsTextDocumentIfExists(id)?.text;
-    } else {
-        throw new Error('Either provide an id property or use inside <WithCmsText> (but not both)');
-    }
+    const contextId = name ? React.useContext(CmsTextContext)?.entries[name] : undefined;
+    const cmsText = useFirstCmsTextDocumentIfExists(id || contextId)?.text;
 
     return cmsText ? (
         <>

--- a/src/components/documents/CmsText/index.tsx
+++ b/src/components/documents/CmsText/index.tsx
@@ -8,7 +8,6 @@ interface Props {
 }
 
 const CmsText = observer(({ id, name }: Props) => {
-
     const contextId = name ? React.useContext(CmsTextContext)?.entries[name] : undefined;
     const cmsText = useFirstCmsTextDocumentIfExists(id || contextId)?.text;
 

--- a/src/components/documents/CmsText/shared.ts
+++ b/src/components/documents/CmsText/shared.ts
@@ -3,12 +3,16 @@ import { useDocumentRoot } from '@tdev-hooks/useDocumentRoot';
 import CmsText, { CmsTextMeta } from '@tdev-models/documents/CmsText';
 
 interface CmsTextContextType {
-    cmsText: string;
+    entries: {[key: string]: string}
 }
 
 export const CmsTextContext = React.createContext<CmsTextContextType | undefined>(undefined);
 
-export function useFirstCmsTextDocumentIfExists(id: string): CmsText | undefined {
+export function useFirstCmsTextDocumentIfExists(id?: string): CmsText | undefined {
+    if (!id) {
+        return undefined;
+    }
+
     // Not using useFirstMainDocument() here because that would always supply a (dummy) document.
     const docRoot = useDocumentRoot(id, new CmsTextMeta({}), false);
     return docRoot?.firstMainDocument;

--- a/src/components/documents/CmsText/shared.ts
+++ b/src/components/documents/CmsText/shared.ts
@@ -3,7 +3,7 @@ import { useDocumentRoot } from '@tdev-hooks/useDocumentRoot';
 import CmsText, { CmsTextMeta } from '@tdev-models/documents/CmsText';
 
 interface CmsTextContextType {
-    entries: {[key: string]: string}
+    entries: { [key: string]: string };
 }
 
 export const CmsTextContext = React.createContext<CmsTextContextType | undefined>(undefined);


### PR DESCRIPTION
In this alternative approach to `<WithCmsText>`, that component takes a dictionary of key to documentRoot IDs, rather than a single ID. It only shows its content, if there is a document available for each entry. Nested `<CmsText>`-elements can refer to the CMS Texts using the keys of that dictionary, rather than having to repeat the UUID.