### PR TITLE
fix missing code lines and missing error-messages

### DIFF
--- a/static/bry-libs/brython_runner.py
+++ b/static/bry-libs/brython_runner.py
@@ -38,7 +38,8 @@ def run(code, node_id, line_shift):
         loc = {}
         exec(py_script, ns)
     except Exception as exc:
-        print_exc(file=sys.stderr, line_shift=log_line_number_shift)
+        fname = re.sub(r'^code_(.*)_[0-9a-f_]{36}$$', r'\1', node_id)
+        print_exc(file=sys.stderr, line_shift=log_line_number_shift, source=code, fname=fname)
     finally:
         notify(node_id, {'type': 'done', 'time': time.time()})
     


### PR DESCRIPTION
- line was not provided in case of a syntax_error and the tb crashed. This was fixed by providing explicitely the source python code
- syntax errors had wrong line numbers due to missing application of line_shift
- filename was always "<string>" - provide it explicitely to use the correct name