### PR TITLE
fix: only provide a dummy quill document, when the user is not logged in...

### DIFF
--- a/src/components/documents/QuillV2/index.tsx
+++ b/src/components/documents/QuillV2/index.tsx
@@ -7,6 +7,7 @@ import { default as QuillV2Model, ModelMeta } from '@tdev-models/documents/Quill
 import { DocContext } from '@tdev-components/documents/DocumentContext';
 import { useStore } from '@tdev-hooks/useStore';
 import Loader from '@tdev-components/Loader';
+import { useFirstRealMainDocument } from '@tdev-hooks/useFirstRealMainDocument';
 
 /**
  * Lazy load QuillV2 component - this is a workaround for SSR
@@ -17,14 +18,13 @@ import Loader from '@tdev-components/Loader';
  */
 
 export const QuillV2 = observer((props: Props) => {
-    const sessionStore = useStore('sessionStore');
-    const doc = useFirstMainDocument(props.id, new ModelMeta(props));
+    const doc = useFirstRealMainDocument(props.id, new ModelMeta(props));
     /**
      * if the user is logged in but the document is not loaded yet, show a loader.
      * This prevents quill from rendering before the document is loaded
      * (which leads to react quill using the wrong quill instance)
      */
-    if (sessionStore.isLoggedIn && (doc.authorId === DUMMY_DOCUMENT_ID || doc.root?.isDummy)) {
+    if (!doc) {
         return <Loader />;
     }
     return <QuillV2Component quillDoc={doc} {...props} />;

--- a/src/components/documents/QuillV2/index.tsx
+++ b/src/components/documents/QuillV2/index.tsx
@@ -2,9 +2,11 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import { observer } from 'mobx-react-lite';
 import * as React from 'react';
 import type { default as QuillV2Type, Props } from './QuillV2';
-import { useFirstMainDocument } from '@tdev-hooks/useFirstMainDocument';
+import { DUMMY_DOCUMENT_ID, useFirstMainDocument } from '@tdev-hooks/useFirstMainDocument';
 import { default as QuillV2Model, ModelMeta } from '@tdev-models/documents/QuillV2';
 import { DocContext } from '@tdev-components/documents/DocumentContext';
+import { useStore } from '@tdev-hooks/useStore';
+import Loader from '@tdev-components/Loader';
 
 /**
  * Lazy load QuillV2 component - this is a workaround for SSR
@@ -15,7 +17,16 @@ import { DocContext } from '@tdev-components/documents/DocumentContext';
  */
 
 export const QuillV2 = observer((props: Props) => {
+    const sessionStore = useStore('sessionStore');
     const doc = useFirstMainDocument(props.id, new ModelMeta(props));
+    /**
+     * if the user is logged in but the document is not loaded yet, show a loader.
+     * This prevents quill from rendering before the document is loaded
+     * (which leads to react quill using the wrong quill instance)
+     */
+    if (sessionStore.isLoggedIn && (doc.authorId === DUMMY_DOCUMENT_ID || doc.root?.isDummy)) {
+        return <Loader />;
+    }
     return <QuillV2Component quillDoc={doc} {...props} />;
 });
 

--- a/src/hooks/useDocumentRoot.ts
+++ b/src/hooks/useDocumentRoot.ts
@@ -6,12 +6,12 @@ import { useStore } from '@tdev-hooks/useStore';
 /**
  * 1. create a dummy documentRoot with default (meta) data
  * 2. create a dummy document with default (meta) data
- * 2. when component mounts, check if the documentRoot is already in the store
- * 3. if not
- *  3.1. add the dummy document to the store
- *  3.2. add the dummy documentRoot to the store
- *  3.3. if an id was provided, load or create the documentRoot and it's documents from the api
- *  3.4. cleanup the dummy document
+ * 3. when component mounts, check if the documentRoot is already in the store
+ * 4. if not:
+ *      1. add the dummy document to the store
+ *      2. add the dummy documentRoot to the store
+ *      3. if an id was provided, load or create the documentRoot and it's documents from the api
+ *      4. cleanup the dummy document
  */
 export const useDocumentRoot = <Type extends DocumentType>(
     id: string | undefined,

--- a/src/hooks/useFirstMainDocument.ts
+++ b/src/hooks/useFirstMainDocument.ts
@@ -6,6 +6,8 @@ import { useDocumentRoot } from '@tdev-hooks/useDocumentRoot';
 import { useStore } from '@tdev-hooks/useStore';
 import { RWAccess } from '@tdev-models/helpers/accessPolicy';
 
+export const DUMMY_DOCUMENT_ID = 'dummy' as const;
+
 /**
  * This hook provides access to the first main document of the rootDocument.
  * This is especially useful, when the DocumentType is expected to have only
@@ -26,7 +28,7 @@ export const useFirstMainDocument = <Type extends DocumentType>(
                 id: defaultDocId,
                 type: meta.type,
                 data: meta.defaultData,
-                authorId: 'dummy',
+                authorId: DUMMY_DOCUMENT_ID,
                 documentRootId: documentRoot.id,
                 parentId: null,
                 createdAt: new Date().toISOString(),

--- a/src/hooks/useFirstMainDocument.ts
+++ b/src/hooks/useFirstMainDocument.ts
@@ -12,6 +12,9 @@ export const DUMMY_DOCUMENT_ID = 'dummy' as const;
  * This hook provides access to the first main document of the rootDocument.
  * This is especially useful, when the DocumentType is expected to have only
  * one main document - like a TaskState.
+ *
+ * For bridging the time until the first main document is loaded,
+ * a dummy document is provided in the meantime.
  */
 export const useFirstMainDocument = <Type extends DocumentType>(
     documentRootId: string | undefined,

--- a/src/hooks/useFirstRealMainDocument.ts
+++ b/src/hooks/useFirstRealMainDocument.ts
@@ -1,0 +1,40 @@
+import { DocumentType } from '@tdev-api/document';
+import { TypeMeta } from '@tdev-models/DocumentRoot';
+import { useStore } from '@tdev-hooks/useStore';
+import { useFirstMainDocument } from './useFirstMainDocument';
+
+export const DUMMY_DOCUMENT_ID = 'dummy' as const;
+
+/**
+ * Bridge the time until the first main document is loaded with a dummy document.
+ */
+export enum BridgeWithDummy {
+    Always = 'always',
+    Never = 'never',
+    WithoutUser = 'without_user' /* when no user is logged in */
+}
+
+/**
+ * This hook provides access to the first main document of the rootDocument.
+ * This is especially useful, when the DocumentType is expected to have only
+ * one main document - like a TaskState.
+ *
+ * Note: This hook is a wrapper around useFirstMainDocument but does not return a dummy document
+ *       or a document with a dummy root document when **a documentRootId was provided**.
+ */
+export const useFirstRealMainDocument = <Type extends DocumentType>(
+    documentRootId: string | undefined,
+    meta: TypeMeta<Type>,
+    createDocument: boolean = true
+) => {
+    const sessionStore = useStore('sessionStore');
+    const mainDoc = useFirstMainDocument(documentRootId, meta, createDocument);
+    if (
+        !!documentRootId &&
+        sessionStore.isLoggedIn &&
+        (mainDoc.authorId === DUMMY_DOCUMENT_ID || mainDoc.root?.isDummy)
+    ) {
+        return;
+    }
+    return mainDoc;
+};

--- a/src/hooks/useFirstRealMainDocument.ts
+++ b/src/hooks/useFirstRealMainDocument.ts
@@ -6,21 +6,13 @@ import { useFirstMainDocument } from './useFirstMainDocument';
 export const DUMMY_DOCUMENT_ID = 'dummy' as const;
 
 /**
- * Bridge the time until the first main document is loaded with a dummy document.
- */
-export enum BridgeWithDummy {
-    Always = 'always',
-    Never = 'never',
-    WithoutUser = 'without_user' /* when no user is logged in */
-}
-
-/**
  * This hook provides access to the first main document of the rootDocument.
  * This is especially useful, when the DocumentType is expected to have only
  * one main document - like a TaskState.
  *
  * Note: This hook is a wrapper around useFirstMainDocument but does not return a dummy document
- *       or a document with a dummy root document when **a documentRootId was provided**.
+ *       (or a document linked to a dummyRootDocument) when **a documentRootId was provided** and
+ *       the session store reports a logged in user.
  */
 export const useFirstRealMainDocument = <Type extends DocumentType>(
     documentRootId: string | undefined,


### PR DESCRIPTION
This fixes the annoying problem, that quill has issues with clearing up current eventlisteners when re-initializing the quill instance (what happens when a new document is passed in). 👉 https://github.com/slab/quill/issues/4237

Workaround: do not pass in a dummy document (at least when there is a documentRootId and the sessionStore reports an authenticated user...)

This PR introduces a new hook: `useFirstRealMainDocument` that is a wrapper around useFirstMainDocument but does not return a dummy document (or a document linked to a dummy rootDocument) when a documentRootId was provided and a user is present.

Is there a better Name for this hook? @SilasBerger 
