### PR TITLE
fix: viewed user permission panel shows always a vertical scroll

### DIFF
--- a/src/components/PermissionsPanel/styles.module.scss
+++ b/src/components/PermissionsPanel/styles.module.scss
@@ -23,5 +23,5 @@
 }
 
 .viewedUserPermissionPanel {
-    overflow-y: scroll;
+    overflow-y: auto;
 }


### PR DESCRIPTION
use `overflow-y: auto` instead of always displaying a scrollbar