### PR TITLE
fix: prevent adding block content to figcaptions

### DIFF
--- a/docs/Komponentengalerie/images.mdx
+++ b/docs/Komponentengalerie/images.mdx
@@ -59,10 +59,10 @@ Zudem kann das Inlining der Quellenangabe (und Bildunterschrift, falls vorhanden
 Die Bildunterschrift kann mit gängigen Markdown-Formatierungen wie **Fett**, *Kursiv* oder `Code` versehen werden
 
 ```md
-![**Fett**, *Kursiv* und :mdi[laptop]{.red} `Code` --width=450px](./images/fat-cursive-code.jpg)
+![**Fett**, *Kursiv*, :mdi[laptop]{.red} `Code` und [Links](#) --width=450px](./images/fat-cursive-code.jpg)
 ```
 <BrowserWindow>
-![**Fett**, *Kursiv* und :mdi[laptop]{.red} `Code` --width=450px](./images/fat-cursive-code.jpg)
+![**Fett**, *Kursiv*, :mdi[laptop]{.red} `Code` und [Links](#formatierung-der-bildunterschrift) --width=450px](./images/fat-cursive-code.jpg)
 </BrowserWindow>
 
 ## Installation

--- a/src/plugins/remark-images/tests/plugin.test.ts
+++ b/src/plugins/remark-images/tests/plugin.test.ts
@@ -3,7 +3,6 @@ import remarkMdx from 'remark-mdx';
 import remarkDirective from 'remark-directive';
 import { describe, expect, it } from 'vitest';
 import { fileURLToPath } from 'url';
-import path from 'path';
 const __filename = fileURLToPath(import.meta.url);
 
 const alignLeft = (content: string) => {
@@ -61,13 +60,7 @@ describe('#image', () => {
         <figure options={{"width":"200px"}}>
           ![Caption](https://example.com/image.png)
 
-          <figcaption>
-            <span style={{flexGrow: 1}} />
-
-            Caption
-
-            <span style={{flexGrow: 1}} />
-          </figcaption>
+          <figcaption><span style={{flexGrow: 1}} />Caption<span style={{flexGrow: 1}} /></figcaption>
         </figure>
         "
       `);
@@ -84,13 +77,7 @@ describe('#image', () => {
       <figure options={{"maxWidth":"200px"}}>
         ![Caption](https://example.com/image.png)
 
-        <figcaption>
-          <span style={{flexGrow: 1}} />
-
-          Caption
-
-          <span style={{flexGrow: 1}} />
-        </figcaption>
+        <figcaption><span style={{flexGrow: 1}} />Caption<span style={{flexGrow: 1}} /></figcaption>
       </figure>
       "
     `);
@@ -107,13 +94,7 @@ describe('#image', () => {
           <figure>
             ![image](https://example.com/image.png)
 
-            <figcaption>
-              <span style={{flexGrow: 1}} />
-
-              image
-
-              <span style={{flexGrow: 1}} />
-            </figcaption>
+            <figcaption><span style={{flexGrow: 1}} />image<span style={{flexGrow: 1}} /></figcaption>
           </figure>
           "
         `);
@@ -130,13 +111,7 @@ describe('#image', () => {
           <figure>
             ![image foo.bar](https://example.com/image.png)
 
-            <figcaption>
-              <span style={{flexGrow: 1}} />
-
-              image [foo.bar](https://foo.bar)
-
-              <span style={{flexGrow: 1}} />
-            </figcaption>
+            <figcaption><span style={{flexGrow: 1}} />image [foo.bar](https://foo.bar)<span style={{flexGrow: 1}} /></figcaption>
           </figure>
           "
         `);
@@ -153,11 +128,7 @@ describe('#image', () => {
           <figure>
             ![](assets/placeholder.svg)
 
-            <figcaption className="inline">
-              <span style={{flexGrow: 1}} />
-
-              <SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} />
-            </figcaption>
+            <figcaption className="inline"><span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
           </figure>
           "
         `);
@@ -178,24 +149,30 @@ describe('#image', () => {
 
     it('processes caption as markdown', async () => {
         const input = `
-        ![a **bold** caption](assets/placeholder.svg)
-        `;
+      ![a **bold** caption](assets/placeholder.svg)
+      `;
         const result = await process(input);
         expect(result).toMatchInlineSnapshot(`
-          "<figure>
-            ![a bold caption](assets/placeholder.svg)
+        "<figure>
+          ![a bold caption](assets/placeholder.svg)
 
-            <figcaption>
-              <span style={{flexGrow: 1}} />
+          <figcaption><span style={{flexGrow: 1}} />a **bold** caption<span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
+        </figure>
+        "
+      `);
+    });
+    it('processes caption as markdown and supports links', async () => {
+        const input = `
+      ![a [link](https://link.com) caption](assets/placeholder.svg)
+      `;
+        const result = await process(input);
+        expect(result).toMatchInlineSnapshot(`
+        "<figure>
+          ![a link caption](assets/placeholder.svg)
 
-              a **bold** caption
-
-              <span style={{flexGrow: 1}} />
-
-              <SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} />
-            </figcaption>
-          </figure>
-          "
-        `);
+          <figcaption><span style={{flexGrow: 1}} />a [link](https://link.com) caption<span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
+        </figure>
+        "
+      `);
     });
 });


### PR DESCRIPTION
Markdown Content:

```md
![a [super useful](#) link](example.com)
```
### Before
Invalid HTML (`p` should not be a child of `figcaption`)
```html
<figure>
    ![a link caption](assets/placeholder.svg)
    <figcaption>

        <span style={{flexGrow: 1}} />

        a [link](https://link.com) caption

        <span style={{flexGrow: 1}} />

    </figcaption>
</figure>
```

### Now

```html
<figure>
    ![a link caption](assets/placeholder.svg)

    <figcaption><span style={{flexGrow: 1}} />a [link](https://link.com) caption<span style={{flexGrow: 1}} /></figcaption>
</figure>
```