### PR TITLE
Refactor/streamline remark plugins

### DIFF
--- a/src/plugins/helpers.ts
+++ b/src/plugins/helpers.ts
@@ -1,5 +1,5 @@
 import { all as KnownCssProperties } from 'known-css-properties';
-import { MdxJsxAttribute, MdxJsxExpressionAttribute } from 'mdast-util-mdx';
+import { MdxJsxAttribute } from 'mdast-util-mdx';
 import type { Directive, MemberExpression, ObjectExpression } from 'estree-jsx';
 // matches options in strings: "--width=200px --height=20%" -> {width: '20px', height='20%'}
 const OPTION_REGEX = /(^|\s+)--(?<key>[a-zA-Z\-]+)\s*=\s*(?<value>[\d\S-]+)/;

--- a/src/plugins/remark-code-defbox/plugin.ts
+++ b/src/plugins/remark-code-defbox/plugin.ts
@@ -20,13 +20,7 @@ const plugin: Plugin<PluginOptions[], Root> = function plugin(this, optionsInput
                 node.children.find((c) => c.type === 'paragraph' && c.data?.directiveLabel) as Paragraph
             )?.children;
             const content = node.children.slice(heading ? 1 : 0);
-            const depth = Math.max(Math.min(Number(node.attributes!.h) || 3, 6), 1) as
-                | 1
-                | 2
-                | 3
-                | 4
-                | 5
-                | 6;
+            const depth = Math.max(Math.min(Number(node.attributes!.h) || 3, 6), 1) as 1 | 2 | 3 | 4 | 5 | 6;
             const defbox: MdxJsxFlowElement = {
                 type: 'mdxJsxFlowElement',
                 name: 'DefBox',

--- a/src/plugins/remark-code-defbox/plugin.ts
+++ b/src/plugins/remark-code-defbox/plugin.ts
@@ -1,6 +1,5 @@
 import type { Plugin, Transformer } from 'unified';
 import { Paragraph, Root } from 'mdast';
-import { ContainerDirective } from 'mdast-util-directive';
 import { MdxJsxFlowElement } from 'mdast-util-mdx';
 
 interface PluginOptions {
@@ -10,26 +9,18 @@ interface PluginOptions {
 }
 
 const plugin: Plugin<PluginOptions[], Root> = function plugin(this, optionsInput = {}): Transformer<Root> {
-    const TAG_NAME = optionsInput?.tagNames?.definition || 'def';
+    const TAG_NAME = optionsInput.tagNames?.definition || 'def';
     return async (root) => {
         const { visit } = await import('unist-util-visit');
-        visit(root, (node, idx, parent) => {
-            if (!parent) {
+        visit(root, 'containerDirective', (node, idx, parent) => {
+            if (!parent || idx === undefined || node.name !== TAG_NAME) {
                 return;
             }
-            if (
-                node.type !== 'containerDirective' ||
-                (node as unknown as ContainerDirective).name !== TAG_NAME ||
-                idx === undefined
-            ) {
-                return;
-            }
-            const directive = node as unknown as ContainerDirective;
             const heading = (
-                directive.children.find((c) => c.type === 'paragraph' && c.data?.directiveLabel) as Paragraph
+                node.children.find((c) => c.type === 'paragraph' && c.data?.directiveLabel) as Paragraph
             )?.children;
-            const content = directive.children.slice(heading ? 1 : 0);
-            const depth = Math.max(Math.min(Number(directive.attributes!.h) || 3, 6), 1) as
+            const content = node.children.slice(heading ? 1 : 0);
+            const depth = Math.max(Math.min(Number(node.attributes!.h) || 3, 6), 1) as
                 | 1
                 | 2
                 | 3

--- a/src/plugins/remark-code-defbox/plugin.ts
+++ b/src/plugins/remark-code-defbox/plugin.ts
@@ -1,21 +1,22 @@
-import { visit } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
-import { Paragraph, Parent } from 'mdast';
+import type { Plugin, Transformer } from 'unified';
+import { Paragraph, Root } from 'mdast';
 import { ContainerDirective } from 'mdast-util-directive';
 import { MdxJsxFlowElement } from 'mdast-util-mdx';
 
-const plugin: Plugin = function plugin(
-    this: Processor,
-    optionsInput?: {
-        tagNames?: {
-            definition?: string;
-        };
-    }
-): Transformer {
-    const TAG_NAME = optionsInput?.tagNames?.definition || 'def';
+interface PluginOptions {
+    tagNames?: {
+        definition?: string;
+    };
+}
 
-    return async (ast, vfile) => {
-        visit(ast, (node, idx, parent: Parent) => {
+const plugin: Plugin<PluginOptions[], Root> = function plugin(this, optionsInput = {}): Transformer<Root> {
+    const TAG_NAME = optionsInput?.tagNames?.definition || 'def';
+    return async (root) => {
+        const { visit } = await import('unist-util-visit');
+        visit(root, (node, idx, parent) => {
+            if (!parent) {
+                return;
+            }
             if (
                 node.type !== 'containerDirective' ||
                 (node as unknown as ContainerDirective).name !== TAG_NAME ||

--- a/src/plugins/remark-comments/plugin.ts
+++ b/src/plugins/remark-comments/plugin.ts
@@ -1,4 +1,5 @@
-import type { Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
+import type { Root } from 'mdast';
 import { Node, Parent } from 'unist';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx';
 import { toJsxAttribute } from '../helpers';
@@ -61,7 +62,9 @@ export interface PluginOptions {
  * This is useful to support comments within mdx documents.
  * A `page_id` in the frontmatter is required to generate the comments.
  */
-const plugin = function plugin(options: PluginOptions): Transformer {
+const plugin: Plugin<PluginOptions[], Root> = function plugin(
+    options = {}
+): Transformer<Root> {
     return async (root, file) => {
         const { page_id, no_comments } = (file.data?.frontMatter || {}) as {
             page_id?: string;

--- a/src/plugins/remark-deflist/README.md
+++ b/src/plugins/remark-deflist/README.md
@@ -34,10 +34,7 @@ will be transformed to
                                 }
                             ]
                         }
-                    ],
-                    "data": {
-                        "_mdxExplicitJsx": true
-                    }
+                    ]
                 },
                 {
                     "type": "mdxJsxFlowElement",
@@ -53,10 +50,7 @@ will be transformed to
                                 }
                             ]
                         }
-                    ],
-                    "data": {
-                        "_mdxExplicitJsx": true
-                    }
+                    ]
                 },
                 {
                     "type": "mdxJsxFlowElement",
@@ -72,10 +66,7 @@ will be transformed to
                                 }
                             ]
                         }
-                    ],
-                    "data": {
-                        "_mdxExplicitJsx": true
-                    }
+                    ]
                 },
                 {
                     "type": "mdxJsxFlowElement",
@@ -91,10 +82,7 @@ will be transformed to
                                 }
                             ]
                         }
-                    ],
-                    "data": {
-                        "_mdxExplicitJsx": true
-                    }
+                    ]
                 },
                 {
                     "type": "mdxJsxFlowElement",
@@ -110,29 +98,11 @@ will be transformed to
                                 }
                             ]
                         }
-                    ],
-                    "data": {
-                        "_mdxExplicitJsx": true
-                    }
+                    ]
                 }
-            ],
-            "data": {
-                "_mdxExplicitJsx": true
-            }
+            ]
         }
-    ],
-    "position": {
-        "start": {
-            "line": 1,
-            "column": 1,
-            "offset": 0
-        },
-        "end": {
-            "line": 7,
-            "column": 1,
-            "offset": 76
-        }
-    }
+    ]
 }
 ```
 

--- a/src/plugins/remark-deflist/plugin.ts
+++ b/src/plugins/remark-deflist/plugin.ts
@@ -176,8 +176,7 @@ const plugin: Plugin<OptionsInput[], Root> = function plugin(this, optionsInput 
                             cIdx = 0;
                         }
                         const dlCandidate = idx > 0 ? parent.children[idx - 1] : undefined;
-                        const hasDL =
-                            dlCandidate?.type === 'mdxJsxFlowElement' && dlCandidate.name === DL;
+                        const hasDL = dlCandidate?.type === 'mdxJsxFlowElement' && dlCandidate.name === DL;
                         const node2move = cParent.children.splice(cIdx, 1)[0];
                         if (node2move.type === 'mdxJsxTextElement' && node2move.name === DT) {
                             action = 'COLLECT_DD_BODY';

--- a/src/plugins/remark-deflist/plugin.ts
+++ b/src/plugins/remark-deflist/plugin.ts
@@ -1,7 +1,7 @@
 import { visit, CONTINUE, SKIP, EXIT } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
-import { BlockContent, Parent, PhrasingContent, Root, RootContent, Text } from 'mdast';
+import { PhrasingContent, Root, RootContent, Text } from 'mdast';
 
 // match to determine if the line is an opening tag
 const DD_REGEX = /(\r?\n):[ \t]+(.*?)/;
@@ -24,7 +24,7 @@ interface OptionsInput {
         dt?: string;
         dd?: string;
     };
-};
+}
 
 const createMdxJsxFlowElementNode = (name: string, children: RootContent[] = [], className?: string) => {
     const attributes = className ? [{ type: 'mdxJsxAttribute', name: 'className', value: className }] : [];
@@ -45,10 +45,7 @@ const createMdxJsxTextElementNode = (name: string, children: RootContent[] = [],
     } as MdxJsxTextElement;
 };
 
-const plugin: Plugin<OptionsInput[], Root> = function plugin(
-    this,
-    optionsInput = {}
-): Transformer<Root> {
+const plugin: Plugin<OptionsInput[], Root> = function plugin(this, optionsInput = {}): Transformer<Root> {
     const { classNames, tagNames } = { tagNames: {}, classNames: {}, ...(optionsInput || {}) };
     const DL = tagNames.dl || 'dl';
     const DT = tagNames.dt || 'dt';
@@ -65,201 +62,199 @@ const plugin: Plugin<OptionsInput[], Root> = function plugin(
         return createMdxJsxTextElementNode(DD, children, classNames.dd);
     };
     return async (ast, vfile) => {
-        visit(ast, (node, _idx, parent) => {
+        visit(ast, 'paragraph', (node, _idx, parent) => {
             if (_idx === undefined || !parent) {
                 return CONTINUE;
             }
-            let idx = _idx as number;
-            if (node.type === 'paragraph') {
-                let action: ActionStates = 'SEEK_DD_START';
-                visit(node, (cNode, _cIdx, cParent) => {
-                    /**
-                     * RULE: only visit the direct children of the paragraph
-                     *       --> only "SKIP" or "EXIT" are returned (except on the first visit)
-                     */
-                    if (!cParent || _cIdx === undefined) {
-                        /** continue to it's children if cParent is not present */
-                        return CONTINUE;
-                    }
-                    let cIdx = _cIdx as number;
-                    switch (action) {
-                        case 'SEEK_DD_START':
-                            if (cNode.type === 'text') {
-                                const ddMatch = cNode.value.match(DD_REGEX);
-                                if (ddMatch) {
-                                    const pre = cNode.value.slice(0, ddMatch.index);
-                                    const dd = cNode.value.slice(ddMatch.index);
-                                    if (pre.trim()) {
-                                        cParent.children.splice(cIdx, 0, {
-                                            type: 'text',
-                                            value: pre
-                                        });
-                                        cIdx++;
-                                    }
-                                    cParent.children.splice(cIdx, 1, {
+            let idx = _idx;
+            let action: ActionStates = 'SEEK_DD_START';
+            visit(node, (cNode, _cIdx, cParent) => {
+                /**
+                 * RULE: only visit the direct children of the paragraph
+                 *       --> only "SKIP" or "EXIT" are returned (except on the first visit)
+                 */
+                if (!cParent || _cIdx === undefined) {
+                    /** continue to it's children if cParent is not present */
+                    return CONTINUE;
+                }
+                let cIdx = _cIdx as number;
+                switch (action) {
+                    case 'SEEK_DD_START':
+                        if (cNode.type === 'text') {
+                            const ddMatch = cNode.value.match(DD_REGEX);
+                            if (ddMatch) {
+                                const pre = cNode.value.slice(0, ddMatch.index);
+                                const dd = cNode.value.slice(ddMatch.index);
+                                if (pre.trim()) {
+                                    cParent.children.splice(cIdx, 0, {
                                         type: 'text',
-                                        value: dd.trimStart().slice(1).trimStart() // remove leading colon
+                                        value: pre
                                     });
-                                    action = 'COLLECT_DT_BODY';
-                                    return [SKIP, cIdx];
+                                    cIdx++;
                                 }
-                            }
-                            return SKIP;
-                        case 'COLLECT_DT_BODY':
-                            if (cIdx === 0) {
-                                /** the dl has no dt */
-                                action = 'COLLECT_DD_BODY';
+                                cParent.children.splice(cIdx, 1, {
+                                    type: 'text',
+                                    value: dd.trimStart().slice(1).trimStart() // remove leading colon
+                                });
+                                action = 'COLLECT_DT_BODY';
                                 return [SKIP, cIdx];
                             }
-                            visit(
-                                cParent,
-                                (dtNode, dtIdx, dtParent) => {
-                                    if (dtIdx === undefined) {
-                                        return CONTINUE;
-                                    }
-                                    const correctNested = dtParent && dtParent === cParent;
-                                    if (!correctNested || dtIdx >= cIdx) {
-                                        if (correctNested) {
-                                            return SKIP;
-                                        }
-                                        return CONTINUE;
-                                    }
-                                    if (dtNode.type === 'text') {
-                                        const text = dtNode as Text;
-                                        const newLineMatch = text.value.match(/\r?\n/);
-                                        if (newLineMatch) {
-                                            const pre = text.value.slice(0, newLineMatch.index);
-                                            const post = text.value.slice(
-                                                (newLineMatch.index || 0) + newLineMatch[0].length
-                                            );
-                                            const newChildren: PhrasingContent[] = [];
-                                            const dtNodes = dtParent.children.splice(
-                                                dtIdx + 1,
-                                                cIdx - (dtIdx + 1)
-                                            );
-                                            if (pre.trim()) {
-                                                newChildren.push({
-                                                    type: 'text',
-                                                    value: pre
-                                                });
-                                            }
-                                            if (post.trim()) {
-                                                dtNodes.splice(0, 0, {
-                                                    type: 'text',
-                                                    value: post
-                                                });
-                                            }
-                                            newChildren.push(getDTNode(dtNodes));
-                                            dtParent.children.splice(dtIdx, 1, ...newChildren);
-                                            action = 'ADD_TO_DL';
-                                            return EXIT;
-                                        }
-                                    }
-                                    if (dtIdx === 0) {
-                                        const dtNodes = dtParent.children.splice(0, cIdx);
-                                        dtParent.children.splice(0, 0, getDTNode(dtNodes));
-                                        action = 'ADD_TO_DL';
-                                        cIdx = 0;
-                                        return EXIT;
-                                    }
-                                    return SKIP;
-                                },
-                                true
-                            );
+                        }
+                        return SKIP;
+                    case 'COLLECT_DT_BODY':
+                        if (cIdx === 0) {
+                            /** the dl has no dt */
+                            action = 'COLLECT_DD_BODY';
                             return [SKIP, cIdx];
-                        case 'ADD_TO_DL':
-                            /** if cIdx != 0, it means the paragraph did not start with
-                             * the deflist. The current paragraph mus be splitted. */
-                            if (cIdx !== 0) {
-                                const pre = cParent.children.splice(0, cIdx) as PhrasingContent[];
-                                parent.children.splice(idx, 0, {
-                                    type: 'paragraph',
-                                    children: pre
-                                });
-                                idx++;
-                                cIdx = 0;
-                            }
-                            const dlCandidate = idx > 0 ? parent.children[idx - 1] : undefined;
-                            const hasDL = dlCandidate?.type === 'mdxJsxFlowElement' && dlCandidate.name === DL;
-                            const node2move = cParent.children.splice(cIdx, 1)[0];
-                            if (node2move.type === 'mdxJsxTextElement' && node2move.name === DT) {
-                                action = 'COLLECT_DD_BODY';
-                            } else {
-                                action = 'SEEK_CONSECUTIVE_DD_START';
-                            }
-
-                            if (hasDL) {
-                                dlCandidate.children.push(node2move as unknown as MdxJsxFlowElement);
-                            } else {
-                                const dl = getDLNode([node2move]);
-                                parent.children.splice(idx, 0, dl);
-                                idx++;
-                            }
-                            if (cParent.children.length === 0) {
-                                parent.children.splice(idx, 1);
-                                return EXIT;
-                            }
-                            return [SKIP, cIdx];
-                        case 'COLLECT_DD_BODY':
-                            visit(cParent, (ddNode, ddIdx, ddParent) => {
-                                if (ddIdx === undefined) {
+                        }
+                        visit(
+                            cParent,
+                            (dtNode, dtIdx, dtParent) => {
+                                if (dtIdx === undefined) {
                                     return CONTINUE;
                                 }
-                                const correctNested = ddParent && ddParent === cParent;
-                                if (!correctNested || ddIdx < cIdx) {
+                                const correctNested = dtParent && dtParent === cParent;
+                                if (!correctNested || dtIdx >= cIdx) {
                                     if (correctNested) {
                                         return SKIP;
                                     }
                                     return CONTINUE;
                                 }
-                                if (ddNode.type === 'text') {
-                                    const text = ddNode as Text;
+                                if (dtNode.type === 'text') {
+                                    const text = dtNode as Text;
                                     const newLineMatch = text.value.match(/\r?\n/);
                                     if (newLineMatch) {
-                                        const dd = text.value.slice(0, newLineMatch.index);
+                                        const pre = text.value.slice(0, newLineMatch.index);
                                         const post = text.value.slice(
                                             (newLineMatch.index || 0) + newLineMatch[0].length
                                         );
-                                        text.value = dd;
-                                        const ddNodes = ddParent.children.splice(cIdx, ddIdx - cIdx + 1);
-                                        ddParent.children.splice(cIdx, 0, getDDNode(ddNodes));
+                                        const newChildren: PhrasingContent[] = [];
+                                        const dtNodes = dtParent.children.splice(
+                                            dtIdx + 1,
+                                            cIdx - (dtIdx + 1)
+                                        );
+                                        if (pre.trim()) {
+                                            newChildren.push({
+                                                type: 'text',
+                                                value: pre
+                                            });
+                                        }
                                         if (post.trim()) {
-                                            ddParent.children.splice(cIdx + 1, 0, {
+                                            dtNodes.splice(0, 0, {
                                                 type: 'text',
                                                 value: post
                                             });
                                         }
+                                        newChildren.push(getDTNode(dtNodes));
+                                        dtParent.children.splice(dtIdx, 1, ...newChildren);
                                         action = 'ADD_TO_DL';
                                         return EXIT;
                                     }
                                 }
-                                if (ddIdx === cParent.children.length - 1) {
+                                if (dtIdx === 0) {
+                                    const dtNodes = dtParent.children.splice(0, cIdx);
+                                    dtParent.children.splice(0, 0, getDTNode(dtNodes));
+                                    action = 'ADD_TO_DL';
+                                    cIdx = 0;
+                                    return EXIT;
+                                }
+                                return SKIP;
+                            },
+                            true
+                        );
+                        return [SKIP, cIdx];
+                    case 'ADD_TO_DL':
+                        /** if cIdx != 0, it means the paragraph did not start with
+                         * the deflist. The current paragraph mus be splitted. */
+                        if (cIdx !== 0) {
+                            const pre = cParent.children.splice(0, cIdx) as PhrasingContent[];
+                            parent.children.splice(idx, 0, {
+                                type: 'paragraph',
+                                children: pre
+                            });
+                            idx++;
+                            cIdx = 0;
+                        }
+                        const dlCandidate = idx > 0 ? parent.children[idx - 1] : undefined;
+                        const hasDL =
+                            dlCandidate?.type === 'mdxJsxFlowElement' && dlCandidate.name === DL;
+                        const node2move = cParent.children.splice(cIdx, 1)[0];
+                        if (node2move.type === 'mdxJsxTextElement' && node2move.name === DT) {
+                            action = 'COLLECT_DD_BODY';
+                        } else {
+                            action = 'SEEK_CONSECUTIVE_DD_START';
+                        }
+
+                        if (hasDL) {
+                            dlCandidate.children.push(node2move as unknown as MdxJsxFlowElement);
+                        } else {
+                            const dl = getDLNode([node2move]);
+                            parent.children.splice(idx, 0, dl);
+                            idx++;
+                        }
+                        if (cParent.children.length === 0) {
+                            parent.children.splice(idx, 1);
+                            return EXIT;
+                        }
+                        return [SKIP, cIdx];
+                    case 'COLLECT_DD_BODY':
+                        visit(cParent, (ddNode, ddIdx, ddParent) => {
+                            if (ddIdx === undefined) {
+                                return CONTINUE;
+                            }
+                            const correctNested = ddParent && ddParent === cParent;
+                            if (!correctNested || ddIdx < cIdx) {
+                                if (correctNested) {
+                                    return SKIP;
+                                }
+                                return CONTINUE;
+                            }
+                            if (ddNode.type === 'text') {
+                                const newLineMatch = ddNode.value.match(/\r?\n/);
+                                if (newLineMatch) {
+                                    const dd = ddNode.value.slice(0, newLineMatch.index);
+                                    const post = ddNode.value.slice(
+                                        (newLineMatch.index || 0) + newLineMatch[0].length
+                                    );
+                                    ddNode.value = dd;
                                     const ddNodes = ddParent.children.splice(cIdx, ddIdx - cIdx + 1);
                                     ddParent.children.splice(cIdx, 0, getDDNode(ddNodes));
+                                    if (post.trim()) {
+                                        ddParent.children.splice(cIdx + 1, 0, {
+                                            type: 'text',
+                                            value: post
+                                        });
+                                    }
                                     action = 'ADD_TO_DL';
                                     return EXIT;
                                 }
-                            });
-                            return [SKIP, cIdx];
-                        case 'SEEK_CONSECUTIVE_DD_START':
-                            if (cNode.type === 'text') {
-                                const ddMatch = cNode.value.match(DD_CONSECUTIVE_REGEX);
-                                if (ddMatch) {
-                                    const dd = cNode.value.slice(ddMatch.index);
-                                    cParent.children.splice(cIdx, 1, {
-                                        type: 'text',
-                                        value: dd.trimStart().slice(1).trimStart() // remove leading colon
-                                    });
-                                    action = 'COLLECT_DD_BODY';
-                                    return [SKIP, cIdx];
-                                }
                             }
-                            action = 'SEEK_DD_START';
-                            return [SKIP, cIdx];
-                    }
-                    return SKIP;
-                });
-            }
+                            if (ddIdx === cParent.children.length - 1) {
+                                const ddNodes = ddParent.children.splice(cIdx, ddIdx - cIdx + 1);
+                                ddParent.children.splice(cIdx, 0, getDDNode(ddNodes));
+                                action = 'ADD_TO_DL';
+                                return EXIT;
+                            }
+                        });
+                        return [SKIP, cIdx];
+                    case 'SEEK_CONSECUTIVE_DD_START':
+                        if (cNode.type === 'text') {
+                            const ddMatch = cNode.value.match(DD_CONSECUTIVE_REGEX);
+                            if (ddMatch) {
+                                const dd = cNode.value.slice(ddMatch.index);
+                                cParent.children.splice(cIdx, 1, {
+                                    type: 'text',
+                                    value: dd.trimStart().slice(1).trimStart() // remove leading colon
+                                });
+                                action = 'COLLECT_DD_BODY';
+                                return [SKIP, cIdx];
+                            }
+                        }
+                        action = 'SEEK_DD_START';
+                        return [SKIP, cIdx];
+                }
+                return SKIP;
+            });
         });
     };
 };

--- a/src/plugins/remark-details/plugin.ts
+++ b/src/plugins/remark-details/plugin.ts
@@ -1,63 +1,51 @@
 import { visit } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
-import { Content, Parent } from 'mdast';
-import { ContainerDirective } from 'mdast-util-directive';
-import { MdxJsxFlowElement } from 'mdast-util-mdx';
+import type { Plugin, Transformer } from 'unified';
+import type { Root } from 'mdast';
+import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx';
 
-const plugin: Plugin = function plugin(
-    this: Processor,
-    optionsInput?: {
-        tagNames?: {
-            details?: string;
-            summary?: string;
-        };
-        classNames?: {
-            details?: string;
-            summary?: string;
-        };
-    }
-): Transformer {
-    const TAG_NAMES = { details: 'details', summary: 'summary', ...optionsInput?.tagNames };
-    const getClassNameAttribute = (tag: 'details' | 'summary') => {
-        const className = (optionsInput?.classNames || {})[tag];
+interface PluginOptions {
+    tagNames?: {
+        details?: string;
+        summary?: string;
+    };
+    classNames?: {
+        details?: string;
+        summary?: string;
+    };
+}
+
+const plugin: Plugin<PluginOptions[], Root> = function plugin(optionsInput = {}): Transformer<Root> {
+    const TAG_NAMES = { details: 'details', summary: 'summary', ...optionsInput.tagNames };
+    const getClassNameAttribute = (tag: 'details' | 'summary'): MdxJsxAttribute[] => {
+        const className = (optionsInput.classNames || {})[tag];
         return className ? [{ type: 'mdxJsxAttribute', name: 'className', value: className }] : [];
     };
 
     return async (ast, vfile) => {
-        visit(ast, (node, idx, parent: Parent) => {
-            if (
-                node.type !== 'containerDirective' ||
-                (node as unknown as ContainerDirective).name !== 'details'
-            ) {
+        visit(ast, 'containerDirective', (node, idx, parent) => {
+            if (!parent || node.name !== 'details') {
                 return;
             }
-            const container = node as unknown as ContainerDirective;
-            const label = container.children.filter(
+            const label = node.children.filter(
                 (child) => (child.data as { directiveLabel: boolean })?.directiveLabel
-            ) as Content[];
-            const content = container.children.filter(
+            );
+            const content = node.children.filter(
                 (child) => !(child.data as { directiveLabel: boolean })?.directiveLabel
-            ) as Content[];
-            const children: Content[] = [...content];
+            );
+            const children = [...content];
             if (label.length > 0) {
                 children.splice(0, 0, {
                     type: 'mdxJsxFlowElement',
                     name: TAG_NAMES.summary,
                     attributes: [...getClassNameAttribute('summary')],
-                    children: label,
-                    data: {
-                        _mdxExplicitJsx: true
-                    }
-                } as MdxJsxFlowElement);
+                    children: label
+                });
             }
             const details = {
                 type: 'mdxJsxFlowElement',
                 name: TAG_NAMES.details,
                 attributes: [...getClassNameAttribute('details')],
-                children: children,
-                data: {
-                    _mdxExplicitJsx: true
-                }
+                children: children
             } as MdxJsxFlowElement;
             parent.children.splice(idx || 0, 1, details);
         });

--- a/src/plugins/remark-details/tests/plugin.test.ts
+++ b/src/plugins/remark-details/tests/plugin.test.ts
@@ -16,7 +16,7 @@ const process = async (content: string) => {
     return result.value;
 };
 
-describe('#flex', () => {
+describe('#details', () => {
     it("does nothing if there's no flex", async () => {
         const input = `# Heading
 

--- a/src/plugins/remark-enumerate-components/plugin.ts
+++ b/src/plugins/remark-enumerate-components/plugin.ts
@@ -5,8 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
+import type { Root } from 'mdast';
 
 export interface PluginOptions {
     componentsToEnumerate?: string[];
@@ -17,14 +18,14 @@ export interface PluginOptions {
  * to the specified components.
  * This is useful to sort components in the order they appear in the document.
  */
-const plugin = function plugin(options: PluginOptions): Transformer {
+const plugin: Plugin<PluginOptions[], Root> = function plugin(options = {}): Transformer<Root> {
     return async (root, file) => {
         const { visit } = await import('unist-util-visit');
         const toEnumerate = new Set<string | null>(options?.componentsToEnumerate || ['Answer']);
         let pagePosition = 0;
 
         visit(root, ['mdxJsxFlowElement', 'mdxJsxTextElement'], (node) => {
-            const answer = node as unknown as MdxJsxFlowElement | MdxJsxTextElement;
+            const answer = node as MdxJsxFlowElement | MdxJsxTextElement;
             if (!toEnumerate.has(answer.name)) {
                 return;
             }

--- a/src/plugins/remark-enumerate-components/plugin.ts
+++ b/src/plugins/remark-enumerate-components/plugin.ts
@@ -8,6 +8,7 @@
 import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
 import type { Root } from 'mdast';
+import { toJsxAttribute } from '../helpers';
 
 export interface PluginOptions {
     componentsToEnumerate?: string[];
@@ -30,31 +31,7 @@ const plugin: Plugin<PluginOptions[], Root> = function plugin(options = {}): Tra
                 return;
             }
             pagePosition = pagePosition + 1;
-            answer.attributes.push({
-                type: 'mdxJsxAttribute',
-                name: 'pagePosition',
-                value: {
-                    type: 'mdxJsxAttributeValueExpression',
-                    value: `${pagePosition}`,
-                    data: {
-                        estree: {
-                            type: 'Program',
-                            body: [
-                                {
-                                    type: 'ExpressionStatement',
-                                    expression: {
-                                        type: 'Literal',
-                                        value: pagePosition,
-                                        raw: `${pagePosition}`
-                                    }
-                                }
-                            ],
-                            sourceType: 'module',
-                            comments: []
-                        }
-                    }
-                }
-            });
+            answer.attributes.push(toJsxAttribute('pagePosition', pagePosition));
         });
     };
 };

--- a/src/plugins/remark-flex-cards/plugin.ts
+++ b/src/plugins/remark-flex-cards/plugin.ts
@@ -56,9 +56,7 @@ const generateContent = (
     return {
         type: 'mdxJsxFlowElement',
         name: 'div',
-        attributes: [
-            toJsxAttribute('className', DEFAULT_CLASSES[type].content)
-        ],
+        attributes: [toJsxAttribute('className', DEFAULT_CLASSES[type].content)],
         children: [],
         data: {
             type: 'content',
@@ -73,9 +71,7 @@ const generateImage = (
     return {
         type: 'mdxJsxFlowElement',
         name: 'div',
-        attributes: [
-            toJsxAttribute('className', 'card__image')
-        ],
+        attributes: [toJsxAttribute('className', 'card__image')],
         children: [image],
         data: {
             type: 'image',
@@ -88,9 +84,7 @@ const generateItem = (type: ContainerDirectiveName, className?: string): MdxJsxF
     return {
         type: 'mdxJsxFlowElement',
         name: 'div',
-        attributes: [
-            toJsxAttribute('className', `${DEFAULT_CLASSES[type].item} ${className || ''}`.trim())
-        ],
+        attributes: [toJsxAttribute('className', `${DEFAULT_CLASSES[type].item} ${className || ''}`.trim())],
         children: [],
         data: {
             _mdxExplicitJsx: true
@@ -183,7 +177,10 @@ const visitor = (ast: Root | MdxJsxFlowElement) => {
             type: 'mdxJsxFlowElement',
             name: 'div',
             attributes: [
-                toJsxAttribute('className', `${DEFAULT_CLASSES[type].container} ${attributes.className}`.trim())
+                toJsxAttribute(
+                    'className',
+                    `${DEFAULT_CLASSES[type].container} ${attributes.className}`.trim()
+                )
             ],
             children: container.children as (BlockContent | DefinitionContent)[]
         } as MdxJsxFlowElement;

--- a/src/plugins/remark-flex-cards/plugin.ts
+++ b/src/plugins/remark-flex-cards/plugin.ts
@@ -57,11 +57,7 @@ const generateContent = (
         type: 'mdxJsxFlowElement',
         name: 'div',
         attributes: [
-            {
-                type: 'mdxJsxAttribute',
-                name: 'className',
-                value: DEFAULT_CLASSES[type].content
-            }
+            toJsxAttribute('className', DEFAULT_CLASSES[type].content)
         ],
         children: [],
         data: {
@@ -78,11 +74,7 @@ const generateImage = (
         type: 'mdxJsxFlowElement',
         name: 'div',
         attributes: [
-            {
-                type: 'mdxJsxAttribute',
-                name: 'className',
-                value: 'card__image'
-            }
+            toJsxAttribute('className', 'card__image')
         ],
         children: [image],
         data: {
@@ -97,11 +89,7 @@ const generateItem = (type: ContainerDirectiveName, className?: string): MdxJsxF
         type: 'mdxJsxFlowElement',
         name: 'div',
         attributes: [
-            {
-                type: 'mdxJsxAttribute',
-                name: 'className',
-                value: `${DEFAULT_CLASSES[type].item} ${className || ''}`.trim()
-            }
+            toJsxAttribute('className', `${DEFAULT_CLASSES[type].item} ${className || ''}`.trim())
         ],
         children: [],
         data: {
@@ -195,11 +183,7 @@ const visitor = (ast: Root | MdxJsxFlowElement) => {
             type: 'mdxJsxFlowElement',
             name: 'div',
             attributes: [
-                {
-                    type: 'mdxJsxAttribute',
-                    name: 'className',
-                    value: `${DEFAULT_CLASSES[type].container} ${attributes.className}`.trim()
-                }
+                toJsxAttribute('className', `${DEFAULT_CLASSES[type].container} ${attributes.className}`.trim())
             ],
             children: container.children as (BlockContent | DefinitionContent)[]
         } as MdxJsxFlowElement;

--- a/src/plugins/remark-images/plugin.ts
+++ b/src/plugins/remark-images/plugin.ts
@@ -27,9 +27,7 @@ interface OptionsInput {
 const SPACER_SPAN = {
     type: 'mdxJsxTextElement',
     name: 'span',
-    attributes: [
-        toJsxAttribute('style', { flexGrow: 1 })
-    ],
+    attributes: [toJsxAttribute('style', { flexGrow: 1 })],
     children: []
 } as MdxJsxTextElement;
 

--- a/src/plugins/remark-images/plugin.ts
+++ b/src/plugins/remark-images/plugin.ts
@@ -1,7 +1,7 @@
 import { visit, SKIP } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxFlowElement, MdxJsxTextElement } from 'mdast-util-mdx';
-import { BlockContent, Content, Image, Paragraph, Parent, PhrasingContent } from 'mdast';
+import { BlockContent, Image, Parent, PhrasingContent, Root } from 'mdast';
 import path from 'path';
 import fs from 'fs';
 import { cleanedText, parseOptions, toJsxAttribute } from '../helpers';
@@ -70,52 +70,46 @@ const SPACER_SPAN = {
             }
         }
     ],
-    children: [],
-    data: {
-        _mdxExplicitJsx: true
-    }
+    children: []
 } as MdxJsxTextElement;
 
-const plugin: Plugin = function plugin(
-    this: Processor,
-    optionsInput: OptionsInput = { tagNames: DEFAULT_TAG_NAMES }
-): Transformer {
+const plugin: Plugin<OptionsInput[], Root> = function plugin(
+    this,
+    optionsInput = { tagNames: DEFAULT_TAG_NAMES }
+): Transformer<Root> {
     return async (ast, vfile) => {
         const dir = path.dirname(vfile.history[0] || optionsInput?.vFile?.history[0] || '');
         const bibPromises = [] as Promise<any>[];
-        visit(ast, (node, idx, parent: Parent) => {
+        visit(ast, ['paragraph', 'image'], (node, idx, parent) => {
+            if (!parent) {
+                return;
+            }
             if (node.type === 'paragraph') {
-                const paragraph = node as unknown as Paragraph;
-                const imagesOnly = paragraph.children.every((n) => {
+                const imagesOnly = node.children.every((n) => {
                     return n.type === 'image' || (n.type === 'text' && n.value.trim() === '');
                 });
                 if (imagesOnly) {
-                    const imgs = paragraph.children.filter((n) => n.type === 'image') as Image[];
+                    const imgs = node.children.filter((n) => n.type === 'image') as Image[];
                     parent.children.splice(idx || 0, 1, ...imgs);
                     return [SKIP, idx];
                 }
-            }
-            if (node.type === 'image') {
-                const image = node as unknown as Image;
-                const line = (image.position?.start?.line || 1) - 1;
+            } else if (node.type === 'image') {
+                const line = (node.position?.start?.line || 1) - 1;
                 const raw = vfile.value
                     .toString()
                     .split('\n')
-                    [line].slice((image.position?.start?.column || 1) - 1, image.position?.end?.column || 0);
-                const rawCaption = raw.slice(2).replace(`](${image.url})`, '');
+                    [line].slice((node.position?.start?.column || 1) - 1, node.position?.end?.column || 0);
+                const rawCaption = raw.slice(2).replace(`](${node.url})`, '');
                 /** get image options and set cleaned alt text */
                 const cleanedAlt = cleanedText(rawCaption || '');
                 const options = parseOptions(rawCaption || '', true);
-                image.alt = cleanedText(image.alt || '');
+                node.alt = cleanedText(node.alt || '');
                 const jsxType = parent.type === 'paragraph' ? 'mdxJsxTextElement' : 'mdxJsxFlowElement';
                 const figure = {
                     type: jsxType,
                     name: optionsInput?.tagNames?.figure || DEFAULT_TAG_NAMES.figure,
                     attributes: Object.keys(options).length > 0 ? [toJsxAttribute('options', options)] : [],
-                    children: [node as Content],
-                    data: {
-                        _mdxExplicitJsx: true
-                    }
+                    children: [node]
                 } as MdxJsxFlowElement | MdxJsxTextElement;
 
                 /**
@@ -125,15 +119,12 @@ const plugin: Plugin = function plugin(
                     type: 'mdxJsxTextElement',
                     name: optionsInput?.tagNames?.figcaption || DEFAULT_TAG_NAMES.figcaption,
                     attributes: [],
-                    children: [],
-                    data: {
-                        _mdxExplicitJsx: true
-                    }
+                    children: []
                 } as MdxJsxFlowElement | MdxJsxTextElement;
 
                 const { inlineCaption = false } = options as any;
                 const { inlineEmptyCaptions = true } = optionsInput;
-                const captionEmpty = /^\s*$/.test(image.alt);
+                const captionEmpty = /^\s*$/.test(node.alt);
                 if (inlineCaption || (captionEmpty && inlineEmptyCaptions)) {
                     caption.attributes.push(toJsxAttribute('className', 'inline'));
                 }
@@ -150,8 +141,8 @@ const plugin: Plugin = function plugin(
                 /**
                  * Try to find a bib file with the same name as the image
                  */
-                const ext = path.extname(image.url);
-                const bibFile = path.resolve(dir, image.url.replace(new RegExp(`${ext}$`), '.json'));
+                const ext = path.extname(node.url);
+                const bibFile = path.resolve(dir, node.url.replace(new RegExp(`${ext}$`), '.json'));
                 const hasBibFile = fs.existsSync(bibFile);
                 if (hasBibFile) {
                     const bibPromise = import(bibFile)
@@ -160,10 +151,7 @@ const plugin: Plugin = function plugin(
                                 type: 'mdxJsxTextElement',
                                 name: optionsInput?.tagNames?.sourceRef || DEFAULT_TAG_NAMES.sourceRef,
                                 attributes: [toJsxAttribute('bib', bib)],
-                                children: [],
-                                data: {
-                                    _mdxExplicitJsx: true
-                                }
+                                children: []
                             } as MdxJsxTextElement;
                             if (!cleanedAlt) {
                                 caption.children.splice(caption.children.length, 0, SPACER_SPAN);

--- a/src/plugins/remark-images/plugin.ts
+++ b/src/plugins/remark-images/plugin.ts
@@ -28,47 +28,7 @@ const SPACER_SPAN = {
     type: 'mdxJsxTextElement',
     name: 'span',
     attributes: [
-        {
-            type: 'mdxJsxAttribute',
-            name: 'style',
-            value: {
-                type: 'mdxJsxAttributeValueExpression',
-                value: '{flexGrow: 1}',
-                data: {
-                    estree: {
-                        type: 'Program',
-                        body: [
-                            {
-                                type: 'ExpressionStatement',
-                                expression: {
-                                    type: 'ObjectExpression',
-                                    properties: [
-                                        {
-                                            type: 'Property',
-                                            method: false,
-                                            shorthand: false,
-                                            computed: false,
-                                            key: {
-                                                type: 'Identifier',
-                                                name: 'flexGrow'
-                                            },
-                                            value: {
-                                                type: 'Literal',
-                                                value: 1,
-                                                raw: '1'
-                                            },
-                                            kind: 'init'
-                                        }
-                                    ]
-                                }
-                            }
-                        ],
-                        sourceType: 'module',
-                        comments: []
-                    }
-                }
-            }
-        }
+        toJsxAttribute('style', { flexGrow: 1 })
     ],
     children: []
 } as MdxJsxTextElement;

--- a/src/plugins/remark-images/tests/plugin.test.ts
+++ b/src/plugins/remark-images/tests/plugin.test.ts
@@ -60,7 +60,7 @@ describe('#image', () => {
         <figure options={{"width":"200px"}}>
           ![Caption](https://example.com/image.png)
 
-          <figcaption><span style={{flexGrow: 1}} />Caption<span style={{flexGrow: 1}} /></figcaption>
+          <figcaption><span style={{"flexGrow":1}} />Caption<span style={{"flexGrow":1}} /></figcaption>
         </figure>
         "
       `);
@@ -77,7 +77,7 @@ describe('#image', () => {
       <figure options={{"maxWidth":"200px"}}>
         ![Caption](https://example.com/image.png)
 
-        <figcaption><span style={{flexGrow: 1}} />Caption<span style={{flexGrow: 1}} /></figcaption>
+        <figcaption><span style={{"flexGrow":1}} />Caption<span style={{"flexGrow":1}} /></figcaption>
       </figure>
       "
     `);
@@ -94,7 +94,7 @@ describe('#image', () => {
           <figure>
             ![image](https://example.com/image.png)
 
-            <figcaption><span style={{flexGrow: 1}} />image<span style={{flexGrow: 1}} /></figcaption>
+            <figcaption><span style={{"flexGrow":1}} />image<span style={{"flexGrow":1}} /></figcaption>
           </figure>
           "
         `);
@@ -111,7 +111,7 @@ describe('#image', () => {
           <figure>
             ![image foo.bar](https://example.com/image.png)
 
-            <figcaption><span style={{flexGrow: 1}} />image [foo.bar](https://foo.bar)<span style={{flexGrow: 1}} /></figcaption>
+            <figcaption><span style={{"flexGrow":1}} />image [foo.bar](https://foo.bar)<span style={{"flexGrow":1}} /></figcaption>
           </figure>
           "
         `);
@@ -128,7 +128,7 @@ describe('#image', () => {
           <figure>
             ![](assets/placeholder.svg)
 
-            <figcaption className="inline"><span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
+            <figcaption className="inline"><span style={{"flexGrow":1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
           </figure>
           "
         `);
@@ -142,7 +142,7 @@ describe('#image', () => {
         expect(result).toMatchInlineSnapshot(`
       "# Heading
 
-      Hello <figure>![](assets/placeholder.svg)<figcaption className="inline"><span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption></figure> my friend.
+      Hello <figure>![](assets/placeholder.svg)<figcaption className="inline"><span style={{"flexGrow":1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption></figure> my friend.
       "
     `);
     });
@@ -156,7 +156,7 @@ describe('#image', () => {
         "<figure>
           ![a bold caption](assets/placeholder.svg)
 
-          <figcaption><span style={{flexGrow: 1}} />a **bold** caption<span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
+          <figcaption><span style={{"flexGrow":1}} />a **bold** caption<span style={{"flexGrow":1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
         </figure>
         "
       `);
@@ -170,7 +170,7 @@ describe('#image', () => {
         "<figure>
           ![a link caption](assets/placeholder.svg)
 
-          <figcaption><span style={{flexGrow: 1}} />a [link](https://link.com) caption<span style={{flexGrow: 1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
+          <figcaption><span style={{"flexGrow":1}} />a [link](https://link.com) caption<span style={{"flexGrow":1}} /><SourceRef bib={{"author":"Flanoz","source":"https://commons.wikimedia.org/wiki/File:Placeholder_view_vector.svg","licence":"CC 0","licence_url":"https://creativecommons.org/publicdomain/zero/1.0/deed.en","edited":false}} /></figcaption>
         </figure>
         "
       `);

--- a/src/plugins/remark-kbd/plugin.ts
+++ b/src/plugins/remark-kbd/plugin.ts
@@ -2,6 +2,7 @@ import { visit, CONTINUE, SKIP } from 'unist-util-visit';
 import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxTextElement } from 'mdast-util-mdx';
 import { Root, Text } from 'mdast';
+import { toJsxAttribute } from '../helpers';
 
 type ActionStates = 'SPLIT_BRACKETS' | 'CREATE_KBD';
 
@@ -11,7 +12,7 @@ interface OptionsInput {
 
 const plugin: Plugin<OptionsInput[], Root> = function plugin(optionsInput = {}): Transformer<Root> {
     const KBD_ATTRIBUTES = optionsInput.className
-        ? [{ type: 'mdxJsxAttribute', name: 'className', value: optionsInput.className }]
+        ? [toJsxAttribute('className', optionsInput.className)]
         : [];
     let actionState: ActionStates = 'SPLIT_BRACKETS';
 

--- a/src/plugins/remark-kbd/plugin.ts
+++ b/src/plugins/remark-kbd/plugin.ts
@@ -1,98 +1,93 @@
 import { visit, CONTINUE, SKIP } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
+import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxTextElement } from 'mdast-util-mdx';
-import { Parent, Text } from 'mdast';
+import { Root, Text } from 'mdast';
 
 type ActionStates = 'SPLIT_BRACKETS' | 'CREATE_KBD';
 
-const plugin: Plugin = function plugin(
-    this: Processor,
-    optionsInput?: {
-        className?: string;
-    }
-): Transformer {
-    const KBD_ATTRIBUTES = optionsInput?.className
+interface OptionsInput {
+    className?: string;
+}
+
+const plugin: Plugin<OptionsInput[], Root> = function plugin(optionsInput = {}): Transformer<Root> {
+    const KBD_ATTRIBUTES = optionsInput.className
         ? [{ type: 'mdxJsxAttribute', name: 'className', value: optionsInput.className }]
         : [];
     let actionState: ActionStates = 'SPLIT_BRACKETS';
 
     return async (ast, vfile) => {
-        visit(ast, (node, idx, parent: Parent) => {
+        visit(ast, 'text', (node, idx, parent) => {
+            if (!parent || idx === undefined) {
+                return;
+            }
             /**
              * visit text nodes and nest all nodes between a kbd sequence [[<content>]] in a kbd mdxJsxTextElement.
              */
-            if (idx !== undefined && node.type === 'text') {
-                const textNode = node as unknown as Text;
-                switch (actionState) {
-                    case 'SPLIT_BRACKETS':
-                        const bracketIdx = [
-                            textNode.value.indexOf('[['),
-                            textNode.value.indexOf(']]')
-                        ].filter((idx) => idx > -1);
-                        if (bracketIdx.length === 0) {
-                            return CONTINUE;
-                        }
-                        parent.data = { ...parent.data, hasKBD: true } as any;
-                        const splitIdx = Math.min(...bracketIdx);
-                        const pre = textNode.value.slice(0, splitIdx);
-                        const bracket = textNode.value.slice(splitIdx, splitIdx + 2);
-                        const post = textNode.value.slice(splitIdx + 2);
+            switch (actionState) {
+                case 'SPLIT_BRACKETS':
+                    const bracketIdx = [node.value.indexOf('[['), node.value.indexOf(']]')].filter(
+                        (idx) => idx > -1
+                    );
+                    if (bracketIdx.length === 0) {
+                        return CONTINUE;
+                    }
+                    parent.data = { ...parent.data, hasKBD: true } as any;
+                    const splitIdx = Math.min(...bracketIdx);
+                    const pre = node.value.slice(0, splitIdx);
+                    const bracket = node.value.slice(splitIdx, splitIdx + 2);
+                    const post = node.value.slice(splitIdx + 2);
 
-                        const splitted = [
-                            {
-                                type: 'text',
-                                value: bracket
-                            }
-                        ] as Text[];
-                        let nextIdx = idx + 1;
+                    const splitted = [
+                        {
+                            type: 'text',
+                            value: bracket
+                        }
+                    ] as Text[];
+                    let nextIdx = idx + 1;
 
-                        if (pre) {
-                            splitted.unshift({
-                                type: 'text',
-                                value: pre
-                            });
-                            nextIdx++;
-                        }
-                        if (post) {
-                            splitted.push({
-                                type: 'text',
-                                value: post
-                            });
-                        }
-                        parent.children.splice(idx, 1, ...splitted);
-                        if (
-                            bracket === ']]' &&
-                            parent.children.slice(0, idx).some((node) => (node as Text).value === '[[')
-                        ) {
-                            actionState = 'CREATE_KBD';
-                            return [SKIP, pre ? idx + 1 : idx];
-                        }
-                        return [CONTINUE, nextIdx];
-                    case 'CREATE_KBD':
-                        if (textNode.value !== ']]') {
-                            throw new Error('Expected closing brackets');
-                        }
-                        /** TODO: TS5 introduced "findLastIndex", but it is currently only supported with target: ESNext */
-                        const reversedIdx = parent.children.length - idx;
-                        const openingIdxReversed = [...parent.children]
-                            .reverse()
-                            .findIndex((node, ind) => ind > reversedIdx && (node as Text).value === '[[');
-                        if (openingIdxReversed === -1) {
-                            throw new Error('Expected opening brackets');
-                        }
-                        const openingIdx = parent.children.length - openingIdxReversed - 1;
-                        parent.children.splice(openingIdx, idx - openingIdx + 1, {
-                            type: 'mdxJsxTextElement',
-                            name: 'kbd',
-                            attributes: [...KBD_ATTRIBUTES],
-                            children: parent.children.slice(openingIdx + 1, idx),
-                            data: {
-                                ['_mdxExplicitJsx']: true
-                            }
-                        } as MdxJsxTextElement);
-                        actionState = 'SPLIT_BRACKETS';
-                        return [CONTINUE, openingIdx];
-                }
+                    if (pre) {
+                        splitted.unshift({
+                            type: 'text',
+                            value: pre
+                        });
+                        nextIdx++;
+                    }
+                    if (post) {
+                        splitted.push({
+                            type: 'text',
+                            value: post
+                        });
+                    }
+                    parent.children.splice(idx, 1, ...splitted);
+                    if (
+                        bracket === ']]' &&
+                        parent.children.slice(0, idx).some((node) => (node as Text).value === '[[')
+                    ) {
+                        actionState = 'CREATE_KBD';
+                        return [SKIP, pre ? idx + 1 : idx];
+                    }
+                    return [CONTINUE, nextIdx];
+                case 'CREATE_KBD':
+                    if (node.value !== ']]') {
+                        throw new Error('Expected closing brackets');
+                    }
+                    /** TODO: TS5 introduced "findLastIndex", but it is currently only supported with target: ESNext */
+                    const reversedIdx = parent.children.length - idx;
+                    const openingIdxReversed = [...parent.children]
+                        .reverse()
+                        .findIndex((node, ind) => ind > reversedIdx && (node as Text).value === '[[');
+                    if (openingIdxReversed === -1) {
+                        throw new Error('Expected opening brackets');
+                    }
+                    const openingIdx = parent.children.length - openingIdxReversed - 1;
+                    parent.children.splice(openingIdx, idx - openingIdx + 1, {
+                        type: 'mdxJsxTextElement',
+                        name: 'kbd',
+                        attributes: [...KBD_ATTRIBUTES],
+                        children: parent.children.slice(openingIdx + 1, idx)
+                    } as MdxJsxTextElement);
+                    actionState = 'SPLIT_BRACKETS';
+                    return [CONTINUE, openingIdx];
             }
         });
     };

--- a/src/plugins/remark-link-annotation/plugin.ts
+++ b/src/plugins/remark-link-annotation/plugin.ts
@@ -1,20 +1,18 @@
-import { visit, CONTINUE, SKIP } from 'unist-util-visit';
-import type { Plugin, Processor, Transformer } from 'unified';
-import type { MdxJsxTextElement } from 'mdast-util-mdx';
-import { Link, Parent, Text } from 'mdast';
-const plugin: Plugin = function plugin(
-    this: Processor,
-    optionsInput?: {
-        prefix?: string | null;
-        postfix?: string | null;
-    }
-): Transformer {
-    const options = optionsInput || {};
-    const prefix = options.prefix === undefined ? '👉' : options.prefix?.trim();
-    const postfix = options.postfix?.trim() || null;
+import { visit } from 'unist-util-visit';
+import type { Plugin, Transformer } from 'unified';
+import { Root, Text } from 'mdast';
+
+interface OptionsInput {
+    prefix?: string | null;
+    postfix?: string | null;
+}
+
+const plugin: Plugin<OptionsInput[], Root> = function plugin(optionsInput = {}): Transformer<Root> {
+    const prefix = optionsInput.prefix === undefined ? '👉' : optionsInput.prefix?.trim();
+    const postfix = optionsInput.postfix?.trim() || null;
 
     return (tree) => {
-        visit(tree, 'link', (node: Link, index, parent) => {
+        visit(tree, 'link', (node) => {
             if (prefix) {
                 if (node.children.length < 1 || node.children[0].type !== 'text') {
                     node.children.unshift({ type: 'text', value: `${prefix} ` } as Text);

--- a/src/plugins/remark-media/tests/plugin.test.ts
+++ b/src/plugins/remark-media/tests/plugin.test.ts
@@ -67,7 +67,9 @@ describe('#medialinks', () => {
         `;
         const result = await process(input);
         expect(result).toMatchInlineSnapshot(`
-          "<iframe width="100%" height="315px" src="https://www.youtube.com/embed/QPZ0pIK_wsc?si=fP8L8fYQ-TYgYwUe" title="YouTube video player" frameBorder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowFullScreen />
+          "<div style={{"width":"100%","aspectRatio":"16 / 9"}}>
+            <iframe width="100%" height="100%" src="https://www.youtube.com/embed/QPZ0pIK_wsc?si=fP8L8fYQ-TYgYwUe" title="YouTube video player" frameBorder="0" allowFullScreen allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" />
+          </div>
           "
         `);
     });

--- a/src/plugins/remark-page/plugin.ts
+++ b/src/plugins/remark-page/plugin.ts
@@ -1,6 +1,6 @@
-import type { Transformer } from 'unified';
-import { Node, Parent } from 'unist';
+import type { Plugin, Transformer } from 'unified';
 import type { MdxJsxFlowElement } from 'mdast-util-mdx';
+import type { Root } from 'mdast';
 import { toJsxAttribute } from '../helpers';
 
 /**
@@ -8,14 +8,14 @@ import { toJsxAttribute } from '../helpers';
  * This is useful to initialize a page model on page load and to trigger side-effects on page display,
  * as to load models attached to the `page_id`'s root document.
  */
-const plugin = function plugin(): Transformer {
+const plugin: Plugin<unknown[], Root> = function plugin(): Transformer<Root> {
     return async (root, file) => {
         const { visit, EXIT } = await import('unist-util-visit');
         const { page_id } = (file.data?.frontMatter || {}) as { page_id?: string };
         if (!page_id) {
             return;
         }
-        visit(root, (node, index, parent: Node | undefined) => {
+        visit(root, (node, index, parent) => {
             /** add the MdxPage exactly once at the top of the document and exit */
             if (root === node && !parent) {
                 const loaderNode: MdxJsxFlowElement = {
@@ -25,7 +25,7 @@ const plugin = function plugin(): Transformer {
                     children: [],
                     data: {}
                 };
-                (node as Parent).children.splice(0, 0, loaderNode);
+                node.children.splice(0, 0, loaderNode);
                 return EXIT;
             }
         });

--- a/src/plugins/remark-page/tests/plugin.test.ts
+++ b/src/plugins/remark-page/tests/plugin.test.ts
@@ -19,7 +19,7 @@ const process = async (content: string, pageId: string | null = 'd2f1b301-fbea-4
     return result.value;
 };
 
-describe('#comment', () => {
+describe('#page', () => {
     it('adds a MdxPage', async () => {
         const input = `# Heading
 

--- a/src/plugins/remark-pdf/tests/plugin.test.ts
+++ b/src/plugins/remark-pdf/tests/plugin.test.ts
@@ -16,7 +16,7 @@ const process = async (content: string) => {
     return result.value;
 };
 
-describe('#links', () => {
+describe('#pdf', () => {
     it("does nothing if there's no pdf", async () => {
         const input = `# Heading
 

--- a/src/plugins/remark-strong/tests/plugin.test.ts
+++ b/src/plugins/remark-strong/tests/plugin.test.ts
@@ -20,7 +20,7 @@ const process = async (content: string) => {
     return result.value;
 };
 
-describe('#underline', () => {
+describe('#strong', () => {
     it("does nothing if there's no underline", async () => {
         const input = `# Heading
 


### PR DESCRIPTION
# streamline remark plugin architectures
- use correct plugin types
- pass in InputOptions
- return a `Transformer<Root>`
- remove obsolet `as unknown as Mdx...` because ts can infer the types now itself

Type the plugins with Plugin<PluginOptions[], Root> and let them return a Transformer<Root> (instead of Transformer only). Like that, TS can infer the types directly:
```ts
const plugin: Plugin<PluginOptions[], Root> = function plugin(
  options,
): Transformer<Root> {
  return async (root, vfile) => {
    const {visit} = await import('unist-util-visit');
    visit(root, 'link', (node, index, parent) => {
      // link is now known to be of type Link

      // parent is of type `Parent | undefined`  and index: `number | undefined`
      // before, parent was of type `never`
      if (index === undefined || !parent) {
        return;
      }
    }
  }
}
```

A helpful resource was: 👉 https://unifiedjs.com/learn/recipe/narrow-node-typescript/