### PR TITLE
feature: support custom directive names for the remark details plugin

### DIFF
--- a/src/plugins/remark-details/plugin.ts
+++ b/src/plugins/remark-details/plugin.ts
@@ -13,7 +13,7 @@ export interface PluginOptions<T extends readonly string[] = readonly string[]> 
         summary?: string;
     };
     classNames?: {
-        [key in T[number] | 'details' | 'summary']: string;
+        [key in T[number] | 'details' | 'summary']?: string;
     };
 }
 

--- a/src/plugins/remark-details/plugin.ts
+++ b/src/plugins/remark-details/plugin.ts
@@ -3,27 +3,31 @@ import type { Plugin, Transformer } from 'unified';
 import type { Root } from 'mdast';
 import type { MdxJsxAttribute, MdxJsxFlowElement } from 'mdast-util-mdx';
 
-interface PluginOptions {
+// TODO: How to type this?
+//       TS doesn't enforce that only keys of directiveNames can be used in
+//       the classNames
+export interface PluginOptions<T extends readonly string[] = readonly string[]> {
+    directiveNames?: T;
     tagNames?: {
         details?: string;
         summary?: string;
     };
     classNames?: {
-        details?: string;
-        summary?: string;
+        [key in T[number] | 'details' | 'summary']: string;
     };
 }
 
 const plugin: Plugin<PluginOptions[], Root> = function plugin(optionsInput = {}): Transformer<Root> {
     const TAG_NAMES = { details: 'details', summary: 'summary', ...optionsInput.tagNames };
-    const getClassNameAttribute = (tag: 'details' | 'summary'): MdxJsxAttribute[] => {
+    const DIRECTIVE_NAMES = new Set(['details', ...(optionsInput.directiveNames || [])]);
+    const getClassNameAttribute = (tag: string): MdxJsxAttribute[] => {
         const className = (optionsInput.classNames || {})[tag];
         return className ? [{ type: 'mdxJsxAttribute', name: 'className', value: className }] : [];
     };
 
     return async (ast, vfile) => {
         visit(ast, 'containerDirective', (node, idx, parent) => {
-            if (!parent || node.name !== 'details') {
+            if (!parent || !DIRECTIVE_NAMES.has(node.name)) {
                 return;
             }
             const label = node.children.filter(
@@ -44,7 +48,7 @@ const plugin: Plugin<PluginOptions[], Root> = function plugin(optionsInput = {})
             const details = {
                 type: 'mdxJsxFlowElement',
                 name: TAG_NAMES.details,
-                attributes: [...getClassNameAttribute('details')],
+                attributes: [...getClassNameAttribute(node.name)],
                 children: children
             } as MdxJsxFlowElement;
             parent.children.splice(idx || 0, 1, details);

--- a/src/plugins/remark-details/tests/plugin.test.ts
+++ b/src/plugins/remark-details/tests/plugin.test.ts
@@ -2,6 +2,7 @@ import { remark } from 'remark';
 import remarkMdx from 'remark-mdx';
 import remarkDirective from 'remark-directive';
 import { describe, expect, it } from 'vitest';
+import { PluginOptions } from '../plugin';
 
 const alignLeft = (content: string) => {
     return content
@@ -9,9 +10,13 @@ const alignLeft = (content: string) => {
         .map((line) => line.trimStart())
         .join('\n');
 };
-const process = async (content: string) => {
+const process = async (content: string, config: PluginOptions = {}) => {
     const { default: plugin } = await import('../plugin');
-    const result = await remark().use(remarkMdx).use(remarkDirective).use(plugin).process(alignLeft(content));
+    const result = await remark()
+        .use(remarkMdx)
+        .use(remarkDirective)
+        .use(plugin, config)
+        .process(alignLeft(content));
 
     return result.value;
 };
@@ -54,17 +59,131 @@ describe('#details', () => {
           Hello world!
           :::
           Byyye!
-      `);
+        `);
         const result = await process(input);
         expect(result).toMatchInlineSnapshot(`
-        "# Details element example
+          "# Details element example
 
-        <details>
+          <details>
+            Hello world!
+          </details>
+
+          Byyye!
+          "
+        `);
+    });
+    it('can set class names', async () => {
+        const input = alignLeft(`# Details element example
+          :::details[hello]
           Hello world!
-        </details>
+          :::
+          Byyye!
+        `);
+        const result = await process(input, { classNames: { details: 'details', summary: 'summary' } });
+        expect(result).toMatchInlineSnapshot(`
+          "# Details element example
 
-        Byyye!
-        "
-      `);
+          <details className="details">
+            <summary className="summary">
+              hello
+            </summary>
+
+            Hello world!
+          </details>
+
+          Byyye!
+          "
+        `);
+    });
+    it('can customize tag names', async () => {
+        const input = alignLeft(`# Details element example
+          :::details[hello]
+          Hello world!
+          :::
+          Byyye!
+        `);
+        const result = await process(input, { tagNames: { details: 'Details', summary: 'Summary' } });
+        expect(result).toMatchInlineSnapshot(`
+          "# Details element example
+
+          <Details>
+            <Summary>
+              hello
+            </Summary>
+
+            Hello world!
+          </Details>
+
+          Byyye!
+          "
+        `);
+    });
+    it('can use custom keywords', async () => {
+        const input = alignLeft(`# Details element example
+            :::solution
+            Hello world!
+            :::
+            Byyye!
+        `);
+        const result = await process(input, { directiveNames: ['solution'] });
+        expect(result).toMatchInlineSnapshot(`
+          "# Details element example
+
+          <details>
+            Hello world!
+          </details>
+
+          Byyye!
+          "
+        `);
+    });
+    it('can use custom keywords with summary', async () => {
+        const input = alignLeft(`# Details element example
+            :::solution[Lösung]
+            Hello world!
+            :::
+            Byyye!
+        `);
+        const result = await process(input, { directiveNames: ['solution'] });
+        expect(result).toMatchInlineSnapshot(`
+          "# Details element example
+
+          <details>
+            <summary>
+              Lösung
+            </summary>
+
+            Hello world!
+          </details>
+
+          Byyye!
+          "
+        `);
+    });
+    it('can use custom keywords with className config', async () => {
+        const input = alignLeft(`# Details element example
+            :::solution[Lösung]
+            Hello world!
+            :::
+            Byyye!
+        `);
+        const result = await process(input, {
+            directiveNames: ['solution'],
+            classNames: { solution: 'solution' }
+        });
+        expect(result).toMatchInlineSnapshot(`
+          "# Details element example
+
+          <details className="solution">
+            <summary>
+              Lösung
+            </summary>
+
+            Hello world!
+          </details>
+
+          Byyye!
+          "
+        `);
     });
 });

--- a/src/plugins/remark-link-annotation/tests/plugin.test.ts
+++ b/src/plugins/remark-link-annotation/tests/plugin.test.ts
@@ -5,11 +5,7 @@ import { describe, expect, it } from 'vitest';
 
 const process = async (content: string, config: { prefix?: string | null; postfix?: string | null } = {}) => {
     const { default: plugin } = await import('../plugin');
-    const result = await remark()
-        .use(remarkMdx)
-        .use(remarkDirective)
-        .use(plugin, config as any)
-        .process(content);
+    const result = await remark().use(remarkMdx).use(remarkDirective).use(plugin, config).process(content);
 
     return result.value;
 };


### PR DESCRIPTION
add option to support more directive names for details, e.g. that `:::solution` will be transformed to a details component.

Used here 👉 https://github.com/GBSL-Informatik/ict-website