### PR TITLE
fix: prevent layout shifts when hovering comments

### DIFF
--- a/src/components/documents/MdxComment/Comment/styles.module.scss
+++ b/src/components/documents/MdxComment/Comment/styles.module.scss
@@ -1,5 +1,6 @@
 .content {
     border-right: 2px solid var(--comment-ico-color);
+    margin-right: -2px;
     border-bottom-right-radius: var(--ifm-alert-border-radius);
     position: relative;
     margin-bottom: 0.4rem;

--- a/src/components/documents/MdxComment/styles.module.scss
+++ b/src/components/documents/MdxComment/styles.module.scss
@@ -128,7 +128,18 @@ h1:has(+ .wrapper) {
 *:hover {
     &:has(+ .wrapper) {
         --comment-ico-color: var(--ifm-color-blue-lighter);
-        border-right: 2px solid var(--comment-ico-color);
+        position: relative;
+        &::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            right: -2px; /* Offset outline */
+            bottom: 0;
+            width: var(--ifm-global-radius); /* Thickness of your "outline" */
+            border-top-right-radius: var(--ifm-global-radius);
+            border-bottom-right-radius: var(--ifm-global-radius);
+            border-right: 2px solid var(--comment-ico-color);
+        }
     }
     + .wrapper {
         .comment {
@@ -166,7 +177,19 @@ h1:has(+ .wrapper) {
 *:has(+ .wrapper.active),
 *:has(+ .wrapper:hover) {
     --comment-ico-color: var(--ifm-color-blue);
-    border-right: 2px solid var(--comment-ico-color);
+    --comment-bottom-radius: var(--ifm-global-radius);
+    position: relative;
+    &::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        right: -2px; /* Offset outline */
+        bottom: 0;
+        width: var(--ifm-global-radius); /* Thickness of your "outline" */
+        border-top-right-radius: var(--ifm-global-radius);
+        border-bottom-right-radius: var(--comment-bottom-radius);
+        border-right: 2px solid var(--comment-ico-color);
+    }
     &:has(+ .wrapper.primary) {
         --comment-ico-color: var(--ifm-color-primary);
     }
@@ -203,5 +226,6 @@ h1:has(+ .wrapper) {
     *:has(+ .wrapper.active.open) {
         margin-bottom: 0;
         border-bottom-right-radius: 0;
+        --comment-bottom-radius: 0;
     }
 }


### PR DESCRIPTION
Currently the right border of a commentable element was modified when hovered. This lead to layout shifts.
This fix uses absolutely positioned pseudo-elements to prevent those layout shifts