### PR TITLE
only show one running turtle container

### DIFF
--- a/src/components/documents/CodeEditor/Editor/index.tsx
+++ b/src/components/documents/CodeEditor/Editor/index.tsx
@@ -12,9 +12,11 @@ import Graphics from './Result/Graphics';
 import Canvas from './Result/Graphics/Canvas';
 import Turtle from './Result/Graphics/Turtle';
 import { observer } from 'mobx-react-lite';
+import { useStore } from '@tdev-hooks/useStore';
 
 const Editor = observer(() => {
     const script = useDocument<DocumentType.Script>();
+    const pageStore = useStore('pageStore');
     return (
         <React.Fragment>
             <Header />
@@ -29,7 +31,9 @@ const Editor = observer(() => {
                     <div id={DOM_ELEMENT_IDS.outputDiv(script.codeId)}></div>
                     {script.graphicsModalExecutionNr > 0 && (
                         <>
-                            {script.hasTurtleOutput && <Turtle />}
+                            {script.hasTurtleOutput && pageStore.runningTurtleScriptId === script.id && (
+                                <Turtle />
+                            )}
                             {script.hasCanvasOutput && <Canvas />}
                             {!script.hasCanvasOutput && !script.hasTurtleOutput && <Graphics />}
                         </>

--- a/src/models/documents/Script.ts
+++ b/src/models/documents/Script.ts
@@ -225,6 +225,9 @@ export default class Script extends iDocument<DocumentType.Script> {
     @action
     execScript() {
         if (this.hasGraphicsOutput) {
+            if (this.hasTurtleOutput) {
+                this.store.root.pageStore.setRunningTurtleScriptId(this.id);
+            }
             this.graphicsModalExecutionNr = this.graphicsModalExecutionNr + 1;
         }
         this.isExecuting = true;

--- a/src/stores/PageStore.ts
+++ b/src/stores/PageStore.ts
@@ -11,6 +11,7 @@ export class PageStore extends iStore {
     pages = observable<Page>([]);
 
     @observable accessor currentPageId: string | undefined = undefined;
+    @observable accessor runningTurtleScriptId: string | undefined = undefined;
 
     constructor(store: RootStore) {
         super();
@@ -68,5 +69,10 @@ export class PageStore extends iStore {
                 );
             });
         });
+    }
+
+    @action
+    setRunningTurtleScriptId(id: string | undefined) {
+        this.runningTurtleScriptId = id;
     }
 }


### PR DESCRIPTION
Since turtles are using svg animations, which are identified by an increasing id independent of how many other animated turtle svg's are present, this works only with one active window