### PR TITLE
refactor: show user permission panel even when no permission exists yet

### DIFF
--- a/src/components/PermissionsPanel/AccessBadge/index.tsx
+++ b/src/components/PermissionsPanel/AccessBadge/index.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import clsx from 'clsx';
+import styles from './styles.module.scss';
+import { observer } from 'mobx-react-lite';
+import { Access } from '@tdev-api/document';
+import Icon from '@mdi/react';
+import { ROAccess, RWAccess } from '@tdev-models/helpers/accessPolicy';
+import { mdiEye, mdiEyeOff, mdiSquareEditOutline } from '@mdi/js';
+const SIZE = 0.8;
+const AccessIcon = (access: Access) => {
+    if (RWAccess.has(access)) {
+        return mdiSquareEditOutline;
+    }
+    if (ROAccess.has(access)) {
+        return mdiEye;
+    }
+    return mdiEyeOff;
+};
+
+interface Props {
+    access?: Access;
+    defaultAccess?: Access;
+    className?: string;
+    size?: number;
+}
+
+const AccessBadge = observer((props: Props) => {
+    return (
+        <div className={clsx('badge', 'badge--secondary', styles.accessBadge, props.className)}>
+            <Icon
+                path={AccessIcon(props.access || props.defaultAccess || Access.None_DocumentRoot)}
+                size={props.size || SIZE}
+                color="var(--ifm-color-blue)"
+            />
+        </div>
+    );
+});
+
+export default AccessBadge;

--- a/src/components/PermissionsPanel/AccessBadge/styles.module.scss
+++ b/src/components/PermissionsPanel/AccessBadge/styles.module.scss
@@ -1,0 +1,3 @@
+.accessBadge {
+    padding: 2px;
+}

--- a/src/components/PermissionsPanel/UserPermission/AccessPanel.tsx
+++ b/src/components/PermissionsPanel/UserPermission/AccessPanel.tsx
@@ -93,7 +93,7 @@ const AccessPanel = observer((props: Props) => {
                                                 if (currentPermission) {
                                                     currentPermission.setAccess(access);
                                                 } else {
-                                                    permissionStore.createUserPermission(dr, user, access);
+                                                    permissionStore.createUserPermission(dr.id, user, access);
                                                 }
                                             });
                                         }}

--- a/src/components/PermissionsPanel/index.tsx
+++ b/src/components/PermissionsPanel/index.tsx
@@ -58,7 +58,7 @@ const PermissionsPanel = observer((props: Props) => {
     }
     const firstRoot = documentRoots[0];
 
-    if (viewedUser && viewedUser !== userStore.current) {
+    if (viewedUser && userStore.isUserSwitched) {
         const userPermissions = documentRoots
             .map((dr) =>
                 permissionStore
@@ -71,7 +71,7 @@ const PermissionsPanel = observer((props: Props) => {
                 className={clsx(styles.viewedUserPermissionPanel, props.className)}
                 onClick={(e) => e.stopPropagation()}
             >
-                <UserPermission permissions={userPermissions} />
+                <UserPermission permissions={userPermissions} documentRootIds={docRootIds} />
             </div>
         );
     }

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -8,6 +8,7 @@ import { Access } from '@tdev-api/document';
 import { useStore } from '@tdev-hooks/useStore';
 import PermissionsPanel from '@tdev-components/PermissionsPanel';
 import { NoneAccess } from '@tdev-models/helpers/accessPolicy';
+import AccessBadge from '@tdev-components/PermissionsPanel/AccessBadge';
 
 interface Props extends MetaInit {
     id: string;
@@ -38,11 +39,15 @@ const Restricted = observer((props: Props) => {
             )}
             <div className={styles.adminControls}>
                 {userStore.current?.isAdmin && <PermissionsPanel documentRootId={docRoot.id} />}
-                {userStore.current?.isAdmin &&
-                    !userStore.isUserSwitched &&
-                    NoneAccess.has(docRoot.permission) && (
-                        <span className="badge badge--secondary">Hidden</span>
-                    )}
+                {userStore.current?.isAdmin && (
+                    <AccessBadge
+                        access={
+                            (userStore.viewedUserId
+                                ? docRoot.permissionForUser(userStore.viewedUserId)
+                                : docRoot.permission) || docRoot.rootAccess
+                        }
+                    />
+                )}
             </div>
         </div>
     );

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -38,9 +38,11 @@ const Restricted = observer((props: Props) => {
             )}
             <div className={styles.adminControls}>
                 {userStore.current?.isAdmin && <PermissionsPanel documentRootId={docRoot.id} />}
-                {userStore.current?.isAdmin && NoneAccess.has(docRoot.permission) && (
-                    <span className="badge badge--secondary">Hidden</span>
-                )}
+                {userStore.current?.isAdmin &&
+                    !userStore.isUserSwitched &&
+                    NoneAccess.has(docRoot.permission) && (
+                        <span className="badge badge--secondary">Hidden</span>
+                    )}
             </div>
         </div>
     );

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -42,10 +42,11 @@ const Restricted = observer((props: Props) => {
                 {userStore.current?.isAdmin && (
                     <AccessBadge
                         access={
-                            (userStore.viewedUserId
+                            userStore.viewedUserId
                                 ? docRoot.permissionForUser(userStore.viewedUserId)
-                                : docRoot.permission) || docRoot.rootAccess
+                                : docRoot.permission
                         }
+                        defaultAccess={docRoot.rootAccess}
                     />
                 )}
             </div>

--- a/src/components/documents/Solution/index.tsx
+++ b/src/components/documents/Solution/index.tsx
@@ -47,10 +47,11 @@ const Solution = observer((props: Props) => {
                                 {userStore.current?.isAdmin && (
                                     <AccessBadge
                                         access={
-                                            (userStore.viewedUserId
+                                            userStore.viewedUserId
                                                 ? docRoot.permissionForUser(userStore.viewedUserId)
-                                                : docRoot.permission) || docRoot.rootAccess
+                                                : docRoot.permission
                                         }
+                                        defaultAccess={docRoot.rootAccess}
                                     />
                                 )}
                                 <Icon

--- a/src/components/documents/Solution/index.tsx
+++ b/src/components/documents/Solution/index.tsx
@@ -43,7 +43,8 @@ const Solution = observer((props: Props) => {
                                 {userStore.current?.isAdmin && (
                                     <PermissionsPanel documentRootId={docRoot.id} />
                                 )}
-                                {NoneAccess.has(docRoot.permission) && (
+                                {!userStore.isUserSwitched && NoneAccess.has(docRoot.permission) && (
+                                    /* only show the "Hidden" Badge when user is **not switched**  */
                                     <span className="badge badge--secondary">Hidden</span>
                                 )}
                                 <Icon

--- a/src/components/documents/Solution/index.tsx
+++ b/src/components/documents/Solution/index.tsx
@@ -12,6 +12,7 @@ import Icon from '@mdi/react';
 import { mdiCheckAll } from '@mdi/js';
 import PermissionsPanel from '@tdev-components/PermissionsPanel';
 import { NoneAccess } from '@tdev-models/helpers/accessPolicy';
+import AccessBadge from '@tdev-components/PermissionsPanel/AccessBadge';
 
 interface Props extends MetaInit {
     id: string;
@@ -43,9 +44,14 @@ const Solution = observer((props: Props) => {
                                 {userStore.current?.isAdmin && (
                                     <PermissionsPanel documentRootId={docRoot.id} />
                                 )}
-                                {!userStore.isUserSwitched && NoneAccess.has(docRoot.permission) && (
-                                    /* only show the "Hidden" Badge when user is **not switched**  */
-                                    <span className="badge badge--secondary">Hidden</span>
+                                {userStore.current?.isAdmin && (
+                                    <AccessBadge
+                                        access={
+                                            (userStore.viewedUserId
+                                                ? docRoot.permissionForUser(userStore.viewedUserId)
+                                                : docRoot.permission) || docRoot.rootAccess
+                                        }
+                                    />
                                 )}
                                 <Icon
                                     path={mdiCheckAll}

--- a/src/stores/PermissionStore.ts
+++ b/src/stores/PermissionStore.ts
@@ -144,13 +144,13 @@ class PermissionStore extends iStore<`update-${string}`> {
     }
 
     @action
-    createUserPermission(documentRoot: DocumentRoot<any>, user: User, access: Access) {
-        this.withAbortController(`create-${documentRoot.id}-${user.id}`, async (signal) => {
+    createUserPermission(documentRootId: string, user: User, access: Access) {
+        this.withAbortController(`create-${documentRootId}-${user.id}`, async (signal) => {
             return createUserPermissionApi(
                 {
                     userId: user.id,
                     access: access,
-                    documentRootId: documentRoot.id
+                    documentRootId: documentRootId
                 },
                 signal.signal
             ).then(({ data }) => {


### PR DESCRIPTION
- fix: show users permission panel when no permission was present yet
- new: display a access badge indicating the current access level of a user

https://github.com/user-attachments/assets/2052482b-3920-45a0-8edc-501612faf9aa

