### PR TITLE
Add basic scrolling to Excel import preview.

### DIFF
--- a/src/components/documents/CmsText/CmsImporter/styles.module.scss
+++ b/src/components/documents/CmsText/CmsImporter/styles.module.scss
@@ -1,3 +1,8 @@
 .assignTable {
     max-height: 12em;
 }
+
+.wrapper {
+    max-height: 100vh;
+    overflow: scroll;
+}


### PR DESCRIPTION
`CmsImporter` wrapper now has `max-height: 100vh` and `overflow: scroll`.