### PR TITLE
feature: user roles and group admins

### DIFF
--- a/src/api/IoEventTypes.ts
+++ b/src/api/IoEventTypes.ts
@@ -4,7 +4,7 @@ import { rootStore } from '../stores/rootStore';
 import { GroupPermission, UserPermission } from '../api/permission';
 import { DocumentRootUpdate } from '../api/documentRoot';
 import { CmsSettings } from './cms';
-import { PartialStudentGroup, StudentGroup } from './studentGroup';
+import { StudentGroup } from './studentGroup';
 
 export enum IoEvent {
     NEW_RECORD = 'NEW_RECORD',
@@ -31,7 +31,7 @@ type TypeRecordMap = {
     [RecordType.GroupPermission]: GroupPermission;
     [RecordType.DocumentRoot]: DocumentRootUpdate;
     [RecordType.CmsSettings]: CmsSettings;
-    [RecordType.StudentGroup]: PartialStudentGroup;
+    [RecordType.StudentGroup]: StudentGroup;
 };
 
 export interface NewRecord<T extends RecordType> {

--- a/src/api/IoEventTypes.ts
+++ b/src/api/IoEventTypes.ts
@@ -4,6 +4,7 @@ import { rootStore } from '../stores/rootStore';
 import { GroupPermission, UserPermission } from '../api/permission';
 import { DocumentRootUpdate } from '../api/documentRoot';
 import { CmsSettings } from './cms';
+import { PartialStudentGroup, StudentGroup } from './studentGroup';
 
 export enum IoEvent {
     NEW_RECORD = 'NEW_RECORD',
@@ -19,6 +20,7 @@ export enum RecordType {
     UserPermission = 'UserPermission',
     GroupPermission = 'GroupPermission',
     DocumentRoot = 'DocumentRoot',
+    StudentGroup = 'StudentGroup',
     CmsSettings = 'CmsSettings'
 }
 
@@ -29,6 +31,7 @@ type TypeRecordMap = {
     [RecordType.GroupPermission]: GroupPermission;
     [RecordType.DocumentRoot]: DocumentRootUpdate;
     [RecordType.CmsSettings]: CmsSettings;
+    [RecordType.StudentGroup]: PartialStudentGroup;
 };
 
 export interface NewRecord<T extends RecordType> {
@@ -105,8 +108,8 @@ export type ServerToClientEvents = {
 };
 
 export interface ClientToServerEvents {
-    [IoClientEvent.JOIN_ROOM]: (roomId: string, callback: () => void) => void;
-    [IoClientEvent.LEAVE_ROOM]: (roomId: string, callback: () => void) => void;
+    [IoClientEvent.JOIN_ROOM]: (roomId: string, callback: (joined: boolean) => void) => void;
+    [IoClientEvent.LEAVE_ROOM]: (roomId: string, callback: (left: boolean) => void) => void;
 }
 
 export const RecordStoreMap: { [key in RecordType]: keyof typeof rootStore } = {
@@ -115,5 +118,6 @@ export const RecordStoreMap: { [key in RecordType]: keyof typeof rootStore } = {
     UserPermission: 'permissionStore',
     GroupPermission: 'permissionStore',
     DocumentRoot: 'documentRootStore',
-    CmsSettings: 'cmsStore'
+    CmsSettings: 'cmsStore',
+    StudentGroup: 'studentGroupStore'
 } as const;

--- a/src/api/studentGroup.ts
+++ b/src/api/studentGroup.ts
@@ -14,11 +14,6 @@ export interface StudentGroup {
     updatedAt: string;
 }
 
-export type PartialStudentGroup = Omit<StudentGroup, 'userIds' | 'adminIds'> & {
-    userIds?: string[];
-    adminIds?: string[];
-};
-
 export function all(signal: AbortSignal): AxiosPromise<StudentGroup[]> {
     return api.get(`/studentGroups`, { signal });
 }

--- a/src/api/studentGroup.ts
+++ b/src/api/studentGroup.ts
@@ -6,6 +6,7 @@ export interface StudentGroup {
     name: string;
     description: string;
     userIds: string[];
+    adminIds: string[];
 
     parentId: string | null;
 
@@ -23,6 +24,15 @@ export function create(data: Partial<StudentGroup> = {}, signal: AbortSignal): A
 
 export function destroy(id: string, signal: AbortSignal): AxiosPromise<StudentGroup> {
     return api.delete(`/studentGroups/${id}`, { signal });
+}
+
+export function setAdminRole(
+    id: string,
+    userId: string,
+    isAdmin: boolean,
+    signal: AbortSignal
+): AxiosPromise<StudentGroup> {
+    return api.post(`/studentGroups/${id}/${userId}`, { isAdmin: isAdmin }, { signal });
 }
 
 export function update(

--- a/src/api/studentGroup.ts
+++ b/src/api/studentGroup.ts
@@ -32,7 +32,7 @@ export function setAdminRole(
     isAdmin: boolean,
     signal: AbortSignal
 ): AxiosPromise<StudentGroup> {
-    return api.post(`/studentGroups/${id}/${userId}`, { isAdmin: isAdmin }, { signal });
+    return api.post(`/studentGroups/${id}/admins/${userId}`, { isAdmin: isAdmin }, { signal });
 }
 
 export function update(

--- a/src/api/studentGroup.ts
+++ b/src/api/studentGroup.ts
@@ -14,6 +14,11 @@ export interface StudentGroup {
     updatedAt: string;
 }
 
+export type PartialStudentGroup = Omit<StudentGroup, 'userIds' | 'adminIds'> & {
+    userIds?: string[];
+    adminIds?: string[];
+};
+
 export function all(signal: AbortSignal): AxiosPromise<StudentGroup[]> {
     return api.get(`/studentGroups`, { signal });
 }

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -8,8 +8,8 @@ export enum Role {
 }
 
 export const RoleNames: { [key in Role]: string } = {
-    [Role.STUDENT]: 'Schüler',
-    [Role.TEACHER]: 'Lehrer',
+    [Role.STUDENT]: 'SuS',
+    [Role.TEACHER]: 'LP',
     [Role.ADMIN]: 'Admin'
 };
 

--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -2,16 +2,29 @@ import api from './base';
 import { AxiosPromise } from 'axios';
 
 export enum Role {
-    USER = 'USER',
+    STUDENT = 'STUDENT',
+    TEACHER = 'TEACHER',
     ADMIN = 'ADMIN'
 }
+
+export const RoleNames: { [key in Role]: string } = {
+    [Role.STUDENT]: 'Schüler',
+    [Role.TEACHER]: 'Lehrer',
+    [Role.ADMIN]: 'Admin'
+};
+
+export const RoleAccessLevel: { [key in Role]: number } = {
+    [Role.STUDENT]: 0,
+    [Role.TEACHER]: 1,
+    [Role.ADMIN]: 2
+};
 
 export type User = {
     id: string;
     email: string;
     firstName: string;
     lastName: string;
-    isAdmin: boolean;
+    role: Role;
     createdAt: string;
     updatedAt: string;
 };

--- a/src/components/Admin/AdminPanel/index.tsx
+++ b/src/components/Admin/AdminPanel/index.tsx
@@ -11,7 +11,7 @@ import AllowedActions from '../AllowedActions';
 
 const AdminPanel = observer(() => {
     const userStore = useStore('userStore');
-    if (!userStore.current?.isAdmin) {
+    if (!userStore.current?.hasElevatedAccess) {
         return (
             <div className="hero shadow--lw">
                 <div className="container">

--- a/src/components/Admin/SelectUser/index.tsx
+++ b/src/components/Admin/SelectUser/index.tsx
@@ -74,7 +74,7 @@ const SelectUser = observer((props: Props) => {
     if (!currentPage) {
         return null;
     }
-    const users = currentPage.activeStudentGroup?.students || userStore.users;
+    const users = currentPage.activeStudentGroup?.students || userStore.managedUsers;
     const selectionState = ids.length === users.length ? 'all' : ids.length === 0 ? 'none' : 'some';
     return (
         <div className={clsx(styles.selectUser, props.className)}>

--- a/src/components/Admin/StudentGroupPanel/index.tsx
+++ b/src/components/Admin/StudentGroupPanel/index.tsx
@@ -33,7 +33,7 @@ const StudentGroupPanel = observer(() => {
             />
             <div className={clsx(styles.studentGroups)}>
                 {_.orderBy(
-                    groupStore.studentGroups.filter((g) => !g.parentId),
+                    groupStore.managedStudentGroups.filter((g) => !g.parentId),
                     ['_pristine.name', 'createdAt'],
                     ['asc', 'desc']
                 ).map((group) => (

--- a/src/components/Admin/StudentGroupPanel/index.tsx
+++ b/src/components/Admin/StudentGroupPanel/index.tsx
@@ -12,7 +12,7 @@ const StudentGroupPanel = observer(() => {
     const userStore = useStore('userStore');
     const groupStore = useStore('studentGroupStore');
     const current = userStore.current;
-    if (!current?.isAdmin) {
+    if (!current?.hasElevatedAccess) {
         return null;
     }
     return (

--- a/src/components/Admin/StudentGroupPanel/index.tsx
+++ b/src/components/Admin/StudentGroupPanel/index.tsx
@@ -7,6 +7,8 @@ import Button from '@tdev-components/shared/Button';
 import { mdiPlusCircleOutline } from '@mdi/js';
 import StudentGroup from '@tdev-components/StudentGroup';
 import _ from 'lodash';
+import scheduleMicrotask from '@tdev-components/util/scheduleMicrotask';
+import { action } from 'mobx';
 
 const StudentGroupPanel = observer(() => {
     const userStore = useStore('userStore');
@@ -19,7 +21,11 @@ const StudentGroupPanel = observer(() => {
         <div>
             <Button
                 onClick={() => {
-                    groupStore.create('Neue Lerngruppe', 'Beschreibung');
+                    groupStore.create('', '').then(
+                        action((group) => {
+                            group?.setEditing(true);
+                        })
+                    );
                 }}
                 icon={mdiPlusCircleOutline}
                 color="primary"
@@ -28,7 +34,7 @@ const StudentGroupPanel = observer(() => {
             <div className={clsx(styles.studentGroups)}>
                 {_.orderBy(
                     groupStore.studentGroups.filter((g) => !g.parentId),
-                    ['name', 'createdAt'],
+                    ['_pristine.name', 'createdAt'],
                     ['asc', 'desc']
                 ).map((group) => (
                     <StudentGroup key={group.id} studentGroup={group} className={clsx(styles.studentGroup)} />

--- a/src/components/Admin/UserTable/User.tsx
+++ b/src/components/Admin/UserTable/User.tsx
@@ -8,6 +8,7 @@ import CopyBadge from '@tdev-components/shared/CopyBadge';
 import { formatDateTime } from '@tdev-models/helpers/date';
 import Icon from '@mdi/react';
 import { mdiCircle } from '@mdi/js';
+import { Role, RoleNames } from '@tdev-api/user';
 
 interface Props {
     user: UserModel;
@@ -32,25 +33,20 @@ const UserTableRow = observer((props: Props) => {
             <td>{user.email}</td>
             <td>
                 <div className={clsx(styles.role, 'button-group')}>
-                    {['Admin', 'User'].map((role, idx) => (
+                    {Object.values(Role).map((role, idx) => (
                         <button
                             key={idx}
                             className={clsx(
                                 'button',
                                 'button--sm',
-                                user.isAdmin
-                                    ? role === 'Admin'
-                                        ? 'button--primary'
-                                        : 'button--secondary'
-                                    : role === 'User'
-                                      ? 'button--primary'
-                                      : 'button--secondary'
+                                role === user.role ? 'button--primary' : 'button--secondary'
                             )}
                             onClick={() => {
-                                user.setAdmin(role === 'Admin');
+                                user.setRole(role);
                             }}
+                            disabled={user.id === user.store.current?.id}
                         >
-                            {role}
+                            {RoleNames[role]}
                         </button>
                     ))}
                 </div>

--- a/src/components/Admin/UserTable/User.tsx
+++ b/src/components/Admin/UserTable/User.tsx
@@ -50,7 +50,11 @@ const UserTableRow = observer((props: Props) => {
                             onClick={() => {
                                 user.setRole(role);
                             }}
-                            disabled={user.id === current.id || current.accessLevel < RoleAccessLevel[role]}
+                            disabled={
+                                user.id === current.id ||
+                                current.accessLevel < RoleAccessLevel[role] ||
+                                user.accessLevel > current.accessLevel
+                            }
                         >
                             {RoleNames[role]}
                         </button>

--- a/src/components/Admin/UserTable/User.tsx
+++ b/src/components/Admin/UserTable/User.tsx
@@ -8,7 +8,8 @@ import CopyBadge from '@tdev-components/shared/CopyBadge';
 import { formatDateTime } from '@tdev-models/helpers/date';
 import Icon from '@mdi/react';
 import { mdiCircle } from '@mdi/js';
-import { Role, RoleNames } from '@tdev-api/user';
+import { Role, RoleAccessLevel, RoleNames } from '@tdev-api/user';
+import { useStore } from '@tdev-hooks/useStore';
 
 interface Props {
     user: UserModel;
@@ -16,6 +17,11 @@ interface Props {
 
 const UserTableRow = observer((props: Props) => {
     const { user } = props;
+    const userStore = useStore('userStore');
+    const { current } = userStore;
+    if (!current) {
+        return null;
+    }
     return (
         <tr className={clsx(styles.user)}>
             <td>
@@ -44,7 +50,7 @@ const UserTableRow = observer((props: Props) => {
                             onClick={() => {
                                 user.setRole(role);
                             }}
-                            disabled={user.id === user.store.current?.id}
+                            disabled={user.id === current.id || current.accessLevel < RoleAccessLevel[role]}
                         >
                             {RoleNames[role]}
                         </button>

--- a/src/components/Admin/UserTable/index.tsx
+++ b/src/components/Admin/UserTable/index.tsx
@@ -13,7 +13,7 @@ const SIZE_S = 0.6;
 
 type SortColumn =
     | 'email'
-    | 'isAdmin'
+    | 'accessLevel'
     | 'firstName'
     | 'lastName'
     | 'createdAt'
@@ -113,9 +113,9 @@ const UserTable = observer((props: Props) => {
                                 <Button
                                     size={SIZE_S}
                                     iconSide="left"
-                                    icon={sortColumn === 'isAdmin' && icon}
-                                    text={'Admin?'}
-                                    onClick={() => setSortColumn('isAdmin')}
+                                    icon={sortColumn === 'accessLevel' && icon}
+                                    text={'Berechtigung'}
+                                    onClick={() => setSortColumn('accessLevel')}
                                 />
                             </th>
                             <th>

--- a/src/components/Admin/UserTable/index.tsx
+++ b/src/components/Admin/UserTable/index.tsx
@@ -47,7 +47,7 @@ const UserTable = observer((props: Props) => {
         const observer = new IntersectionObserver(
             (entries) => {
                 if (entries[0].isIntersecting) {
-                    if (itemsShown < userStore.users.length) {
+                    if (itemsShown < userStore.managedUsers.length) {
                         setItemsShown((prev) => prev + 20);
                     }
                 }
@@ -64,7 +64,7 @@ const UserTable = observer((props: Props) => {
                 observer.unobserve(observerTarget.current);
             }
         };
-    }, [observerTarget, userStore.users.length]);
+    }, [observerTarget, userStore.managedUsers.length]);
 
     const setSortColumn = (column: SortColumn) => {
         if (column === sortColumn) {
@@ -85,7 +85,9 @@ const UserTable = observer((props: Props) => {
                     onChange={(e) => setFilter(e.target.value)}
                     placeholder="🔎 Suche"
                 />
-                <span className={clsx('badge', 'badge--primary')}>{`Users: ${userStore.users.length}`}</span>
+                <span
+                    className={clsx('badge', 'badge--primary')}
+                >{`Users: ${userStore.managedUsers.length}`}</span>
             </div>
             <div className={clsx(styles.tableWrapper)}>
                 <table className={clsx(styles.table)}>
@@ -175,9 +177,9 @@ const UserTable = observer((props: Props) => {
                         </tr>
                     </thead>
                     <tbody>
-                        {_.orderBy(userStore.users, [sortColumn], [sortDirection])
+                        {_.orderBy(userStore.managedUsers, [sortColumn], [sortDirection])
                             .filter((user) => searchRegex.test(user.searchTerm))
-                            .slice(0, props.showAll ? userStore.users.length : itemsShown)
+                            .slice(0, props.showAll ? userStore.managedUsers.length : itemsShown)
                             .map((user, idx) => {
                                 return <UserTableRow key={user.id} user={user} />;
                             })}

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -18,7 +18,7 @@ const AccountSwitcher = observer(() => {
 
     const klass = location.pathname.split('/')[1];
 
-    if (!isBrowser || !userStore.current?.isAdmin) {
+    if (!isBrowser || !userStore.current?.hasElevatedAccess) {
         return null;
     }
     return (

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -60,7 +60,9 @@ const AccountSwitcher = observer(() => {
                     <div className={clsx('card__body', styles.body)}>
                         <div className={styles.userList}>
                             {_.orderBy(
-                                userStore.users.filter((g) => g.studentGroups.some((g) => g.name === klass)),
+                                userStore.managedUsers.filter((g) =>
+                                    g.studentGroups.some((g) => g.name === klass)
+                                ),
                                 ['firstName']
                             ).map((user) => (
                                 <Button
@@ -78,7 +80,9 @@ const AccountSwitcher = observer(() => {
                                 </Button>
                             ))}
                             {_.orderBy(
-                                userStore.users.filter((g) => !g.studentGroups.some((g) => g.name === klass)),
+                                userStore.managedUsers.filter(
+                                    (g) => !g.studentGroups.some((g) => g.name === klass)
+                                ),
                                 ['firstName']
                             ).map((user) => (
                                 <Button

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -60,8 +60,8 @@ const AccountSwitcher = observer(() => {
                     <div className={clsx('card__body', styles.body)}>
                         <div className={styles.userList}>
                             {_.orderBy(
-                                userStore.managedUsers.filter((g) =>
-                                    g.studentGroups.some((g) => g.name === klass)
+                                userStore.managedUsers.filter((u) =>
+                                    u.studentGroups.some((g) => g.name === klass)
                                 ),
                                 ['firstName']
                             ).map((user) => (

--- a/src/components/PermissionsPanel/GroupPermission/AccessPanel.tsx
+++ b/src/components/PermissionsPanel/GroupPermission/AccessPanel.tsx
@@ -73,7 +73,7 @@ const AccessPanel = observer((props: Props) => {
                                 <GroupPermission permissions={groupPermissions} />
                             </div>
                         ))}
-                    {studentGroupStore.studentGroups
+                    {studentGroupStore.managedStudentGroups
                         .filter(
                             (group) =>
                                 searchRegex.test(group.searchTerm) &&

--- a/src/components/PermissionsPanel/UserPermission/AccessPanel.tsx
+++ b/src/components/PermissionsPanel/UserPermission/AccessPanel.tsx
@@ -72,7 +72,7 @@ const AccessPanel = observer((props: Props) => {
                                 <UserPermission permissions={userPermissions} />
                             </div>
                         ))}
-                    {userStore.users
+                    {userStore.managedUsers
                         .filter(
                             (user) =>
                                 searchRegex.test(user.searchTerm) &&

--- a/src/components/PermissionsPanel/index.tsx
+++ b/src/components/PermissionsPanel/index.tsx
@@ -53,7 +53,7 @@ const PermissionsPanel = observer((props: Props) => {
     const documentRoots = docRootIds.map((did) => documentRootStore.find(did)).filter((x) => !!x);
     const { viewedUser } = userStore;
 
-    if (!userStore.current?.isAdmin || documentRoots.length === 0) {
+    if (!userStore.current?.hasElevatedAccess || documentRoots.length === 0) {
         return null;
     }
     const firstRoot = documentRoots[0];

--- a/src/components/StudentGroup/index.tsx
+++ b/src/components/StudentGroup/index.tsx
@@ -152,7 +152,7 @@ const StudentGroup = observer((props: Props) => {
                                     }}
                                 >
                                     <option value="">Keine</option>
-                                    {groupStore.studentGroups
+                                    {groupStore.managedStudentGroups
                                         .filter((g) => g.id !== group.id)
                                         .map((g) => (
                                             <option key={g.id} value={g.id}>

--- a/src/components/StudentGroup/index.tsx
+++ b/src/components/StudentGroup/index.tsx
@@ -31,7 +31,6 @@ interface Props {
 
 const StudentGroup = observer((props: Props) => {
     const [removedIds, setRemovedIds] = React.useState<string[]>([]);
-    const ref = React.useRef<HTMLInputElement>(null);
     const userStore = useStore('userStore');
     const groupStore = useStore('studentGroupStore');
     const group = props.studentGroup;

--- a/src/components/StudentGroup/index.tsx
+++ b/src/components/StudentGroup/index.tsx
@@ -7,9 +7,10 @@ import Button from '@tdev-components/shared/Button';
 import {
     mdiAccountKey,
     mdiAccountKeyOutline,
-    mdiAccountOff,
     mdiAccountReactivateOutline,
     mdiCircleEditOutline,
+    mdiClose,
+    mdiCloseBox,
     mdiCloseCircleOutline,
     mdiContentSave,
     mdiFileExcelOutline,
@@ -202,7 +203,8 @@ const StudentGroup = observer((props: Props) => {
                                                     size={SIZE_S}
                                                     confirmText="Admin aus Gruppe entfernen?"
                                                     confirmColor="red"
-                                                    icon={mdiAccountOff}
+                                                    icon={mdiClose}
+                                                    confirmIcon={mdiCloseBox}
                                                     title={
                                                         group.admins.length === 1
                                                             ? 'Eine Gruppe ohne Admins ist nicht zulässig'
@@ -245,7 +247,7 @@ const StudentGroup = observer((props: Props) => {
                                                         ]);
                                                     }}
                                                     size={SIZE_S}
-                                                    icon={mdiAccountOff}
+                                                    icon={mdiClose}
                                                     color="red"
                                                     title="Entfernen"
                                                 />

--- a/src/components/StudentGroup/index.tsx
+++ b/src/components/StudentGroup/index.tsx
@@ -164,7 +164,7 @@ const StudentGroup = observer((props: Props) => {
                     <dt>Anzahl Schüler:innen</dt>
                     <dd>
                         <span className={clsx('badge badge--primary')}>
-                            {group.students.filter((u) => !u.isAdmin).length}
+                            {group.students.filter((u) => !u.hasElevatedAccess).length}
                         </span>
                     </dd>
                     <dt>Admins</dt>

--- a/src/components/StudentGroup/styles.module.scss
+++ b/src/components/StudentGroup/styles.module.scss
@@ -30,7 +30,6 @@
             flex-wrap: wrap;
             flex-direction: row;
             padding-left: 0;
-            gap: 0.5em;
             .listItem {
                 flex-basis: 10em;
                 flex-grow: 1;
@@ -46,9 +45,6 @@
                 }
                 .actions {
                     display: flex;
-                    button {
-                        margin-left: 1rem;
-                    }
                 }
             }
         }

--- a/src/components/documents/CmsText/CmsImporter/index.tsx
+++ b/src/components/documents/CmsText/CmsImporter/index.tsx
@@ -77,7 +77,7 @@ const CmsImporter = observer((props: Props) => {
     const closeTooltip = () => {
         (ref.current as any)?.close();
     };
-    if (!userStore.current?.isAdmin || userStore.isUserSwitched) {
+    if (!userStore.current?.hasElevatedAccess || userStore.isUserSwitched) {
         return null;
     }
     return (

--- a/src/components/documents/DynamicDocumentRoots/AddDynamicDocumentRoot/index.tsx
+++ b/src/components/documents/DynamicDocumentRoots/AddDynamicDocumentRoot/index.tsx
@@ -16,7 +16,7 @@ const AddDynamicDocumentRoot = observer((props: Props) => {
     const { dynamicDocumentRoots } = props;
     const userStore = useStore('userStore');
     const user = userStore.current;
-    if (!user || !user.isAdmin) {
+    if (!user || !user.hasElevatedAccess) {
         return null;
     }
 

--- a/src/components/documents/DynamicDocumentRoots/index.tsx
+++ b/src/components/documents/DynamicDocumentRoots/index.tsx
@@ -22,7 +22,7 @@ const DynamicDocumentRoots = observer((props: Props) => {
     const [meta] = React.useState(new ModelMeta(props));
     const userStore = useStore('userStore');
     const user = userStore.current;
-    const doc = useFirstRealMainDocument(props.id, meta, user?.isAdmin, {
+    const doc = useFirstRealMainDocument(props.id, meta, user?.hasElevatedAccess, {
         access: Access.RO_DocumentRoot,
         /**
          * there is only one document root for dynamic document roots

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -32,14 +32,14 @@ const Restricted = observer((props: Props) => {
     return (
         <div className={styles.wrapper}>
             {!NoneAccess.has(props.access) &&
-            (!NoneAccess.has(docRoot.permission) || userStore.current?.isAdmin) ? (
+            (!NoneAccess.has(docRoot.permission) || userStore.current?.hasElevatedAccess) ? (
                 <div>{props.children}</div>
             ) : (
                 <div></div>
             )}
             <div className={styles.adminControls}>
-                {userStore.current?.isAdmin && <PermissionsPanel documentRootId={docRoot.id} />}
-                {userStore.current?.isAdmin && (
+                {userStore.current?.hasElevatedAccess && <PermissionsPanel documentRootId={docRoot.id} />}
+                {userStore.current?.hasElevatedAccess && (
                     <AccessBadge
                         access={
                             userStore.viewedUserId

--- a/src/components/documents/Solution/index.tsx
+++ b/src/components/documents/Solution/index.tsx
@@ -34,17 +34,17 @@ const Solution = observer((props: Props) => {
     return (
         <div className={clsx(styles.wrapper, props.standalone && styles.standalone)}>
             {!NoneAccess.has(props.access) &&
-            (!NoneAccess.has(docRoot.permission) || userStore.current?.isAdmin) ? (
+            (!NoneAccess.has(docRoot.permission) || userStore.current?.hasElevatedAccess) ? (
                 <Details
                     summary={
                         <summary>
                             <div className={styles.summary}>
                                 {props.title || 'Lösung'}
                                 <div style={{ flex: '1 1 0' }} />
-                                {userStore.current?.isAdmin && (
+                                {userStore.current?.hasElevatedAccess && (
                                     <PermissionsPanel documentRootId={docRoot.id} />
                                 )}
-                                {userStore.current?.isAdmin && (
+                                {userStore.current?.hasElevatedAccess && (
                                     <AccessBadge
                                         access={
                                             userStore.viewedUserId

--- a/src/components/documents/TaskState/TaskStateOverview/index.tsx
+++ b/src/components/documents/TaskState/TaskStateOverview/index.tsx
@@ -62,7 +62,7 @@ const TaskStateOverview = observer(() => {
     const allChecked = someChecked && taskStates.every((d) => d.taskState === 'checked');
     return (
         <div className={clsx(styles.taskStateOverview)}>
-            {currentUser.isAdmin ? (
+            {currentUser.hasElevatedAccess ? (
                 <Popup
                     trigger={
                         <div className={styles.icon}>

--- a/src/components/shared/FromXlsxClipboard/index.tsx
+++ b/src/components/shared/FromXlsxClipboard/index.tsx
@@ -34,7 +34,7 @@ const FromXlsxClipboard = (props: Props) => {
             .map((row, idx) => {
                 const cells = row.split('\t');
                 if (props.matchUsers) {
-                    const user = userStore.users.find((u) => u.searchRegex.test(row));
+                    const user = userStore.managedUsers.find((u) => u.searchRegex.test(row));
                     if (user) {
                         cells.unshift(user.id);
                     } else {

--- a/src/components/shared/PageStudentGroupFilter/index.tsx
+++ b/src/components/shared/PageStudentGroupFilter/index.tsx
@@ -22,7 +22,7 @@ const PageStudentGroupFilter = observer(() => {
     return (
         <div>
             <div className={clsx(styles.studentGroupSelector, 'button-group button-group--block')}>
-                {studentGroupStore.studentGroups
+                {studentGroupStore.managedStudentGroups
                     .filter((sg) => !sg.parentId)
                     .map((group, idx) => {
                         return (

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -138,7 +138,7 @@ class DocumentRoot<T extends DocumentType> {
      * This method should be used only for admin users.
      */
     get allDocuments() {
-        if (!this.store.root.userStore.current?.isAdmin) {
+        if (!this.store.root.userStore.current?.hasElevatedAccess) {
             return this.documents;
         }
         return this.store.root.documentStore.findByDocumentRoot(this.id);
@@ -172,7 +172,10 @@ class DocumentRoot<T extends DocumentType> {
         }
         const byUser = docs.filter((d) => d.authorId === this.viewedUserId);
 
-        if (this.store.root.userStore.current?.isAdmin && this.store.root.userStore.isUserSwitched) {
+        if (
+            this.store.root.userStore.current?.hasElevatedAccess &&
+            this.store.root.userStore.isUserSwitched
+        ) {
             return byUser;
         }
 
@@ -208,7 +211,7 @@ class DocumentRoot<T extends DocumentType> {
 
     @computed
     get hasAdminRWAccess() {
-        return this.hasRWAccess || !!this.store.root.userStore.current?.isAdmin;
+        return this.hasRWAccess || !!this.store.root.userStore.current?.hasElevatedAccess;
     }
 }
 

--- a/src/models/GroupPermission.ts
+++ b/src/models/GroupPermission.ts
@@ -50,7 +50,7 @@ class GroupPermission {
         if (!userIds) {
             return [];
         }
-        return this.store.root.userStore.users.filter((u) => userIds.has(u.id));
+        return this.store.root.userStore.managedUsers.filter((u) => userIds.has(u.id));
     }
 
     isAffectingUser(user: User) {

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -98,7 +98,7 @@ export default class Page {
             return this.primaryStudentGroup.children;
         }
         return _.orderBy(
-            this.store.root.studentGroupStore.studentGroups.filter((sg) => !!sg.parentId),
+            this.store.root.studentGroupStore.managedStudentGroups.filter((sg) => !!sg.parentId),
             ['name'],
             ['asc']
         );

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -16,6 +16,7 @@ class StudentGroup {
     adminIds = observable.set<string>([]);
 
     @observable accessor parentId: string | null;
+    @observable accessor isEditing: boolean = false;
 
     readonly _pristine: { name: string; description: string };
 
@@ -73,6 +74,11 @@ class StudentGroup {
     }
 
     @action
+    setEditing(isEditing: boolean) {
+        this.isEditing = isEditing;
+    }
+
+    @action
     setDescription(description: string) {
         this.description = description;
     }
@@ -93,17 +99,17 @@ class StudentGroup {
     }
 
     @computed
-    get isAdmin() {
+    get isGroupAdmin() {
         const { current } = this.store.root.userStore;
-        if (!current) {
+        if (!current || !current.hasElevatedAccess) {
             return false;
         }
-        return current.hasElevatedAccess || this.adminIds.has(current.id);
+        return current.isAdmin || this.adminIds.has(current.id);
     }
 
     @action
     setAdminRole(user: User, isAdmin: boolean) {
-        if (!this.isAdmin) {
+        if (!this.isGroupAdmin) {
             return;
         }
         return this.store.setAdminRole(this, user, isAdmin);

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -98,7 +98,7 @@ class StudentGroup {
         if (!current) {
             return false;
         }
-        return current.isAdmin || this.adminIds.has(current.id);
+        return current.hasElevatedAccess || this.adminIds.has(current.id);
     }
 
     @action

--- a/src/models/StudentGroup.ts
+++ b/src/models/StudentGroup.ts
@@ -13,6 +13,7 @@ class StudentGroup {
     @observable accessor description: string;
 
     userIds = observable.set<string>([]);
+    adminIds = observable.set<string>([]);
 
     @observable accessor parentId: string | null;
 
@@ -30,6 +31,7 @@ class StudentGroup {
         this.description = props.description;
 
         this.userIds.replace(props.userIds);
+        this.adminIds.replace(props.adminIds);
         this.parentId = props.parentId || null;
 
         this.updatedAt = new Date(props.updatedAt);
@@ -46,7 +48,14 @@ class StudentGroup {
 
     @computed
     get students() {
-        return this.store.root.userStore.users.filter((u) => this.userIds.has(u.id));
+        return this.store.root.userStore.users.filter(
+            (u) => this.userIds.has(u.id) && !this.adminIds.has(u.id)
+        );
+    }
+
+    @computed
+    get admins() {
+        return this.store.root.userStore.users.filter((u) => this.adminIds.has(u.id));
     }
 
     @computed
@@ -79,14 +88,31 @@ class StudentGroup {
     }
 
     @action
-    reset() {
-        this.name = this._pristine.name;
-        this.description = this._pristine.description;
+    removeStudent(student: User) {
+        return this.store.removeUser(this, student);
+    }
+
+    @computed
+    get isAdmin() {
+        const { current } = this.store.root.userStore;
+        if (!current) {
+            return false;
+        }
+        return current.isAdmin || this.adminIds.has(current.id);
     }
 
     @action
-    removeStudent(student: User) {
-        return this.store.removeUser(this, student);
+    setAdminRole(user: User, isAdmin: boolean) {
+        if (!this.isAdmin) {
+            return;
+        }
+        return this.store.setAdminRole(this, user, isAdmin);
+    }
+
+    @action
+    reset() {
+        this.name = this._pristine.name;
+        this.description = this._pristine.description;
     }
 
     @action
@@ -95,7 +121,7 @@ class StudentGroup {
     }
 
     @computed
-    get props(): Omit<StudentGroupProps, 'userIds' | 'createdAt' | 'updatedAt'> {
+    get props(): Omit<StudentGroupProps, 'userIds' | 'createdAt' | 'updatedAt' | 'adminIds'> {
         return {
             id: this.id,
             name: this.name,

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,5 +1,5 @@
 import { action, computed } from 'mobx';
-import { User as UserProps } from '@tdev-api/user';
+import { Role, RoleAccessLevel, User as UserProps } from '@tdev-api/user';
 import { UserStore } from '@tdev-stores/UserStore';
 import siteConfig from '@generated/docusaurus.config';
 const { STUDENT_USERNAME_PATTERN } = siteConfig.customFields as { STUDENT_USERNAME_PATTERN?: string };
@@ -12,7 +12,7 @@ export default class User {
     readonly firstName: string;
     readonly lastName: string;
 
-    readonly isAdmin: boolean;
+    readonly role: Role;
     readonly createdAt: Date;
     readonly updatedAt: Date;
 
@@ -20,7 +20,7 @@ export default class User {
         this.store = store;
         this.id = props.id;
         this.email = props.email;
-        this.isAdmin = props.isAdmin;
+        this.role = props.role || Role.STUDENT;
         this.firstName = props.firstName;
         this.lastName = props.lastName;
         this.createdAt = new Date(props.createdAt);
@@ -28,10 +28,20 @@ export default class User {
     }
 
     @computed
+    get accessLevel() {
+        return RoleAccessLevel[this.role] || 0;
+    }
+
+    @computed
+    get hasElevatedAccess() {
+        return this.accessLevel > 0;
+    }
+
+    @computed
     get isStudent() {
         return STUDENT_USERNAME_PATTERN
             ? new RegExp(STUDENT_USERNAME_PATTERN, 'i').test(this.email)
-            : !this.isAdmin;
+            : !this.hasElevatedAccess;
     }
 
     get isTeacher() {
@@ -56,7 +66,7 @@ export default class User {
         return {
             id: this.id,
             email: this.email,
-            isAdmin: this.isAdmin,
+            role: this.role,
             firstName: this.firstName,
             lastName: this.lastName,
             createdAt: this.createdAt.toISOString(),
@@ -83,8 +93,8 @@ export default class User {
     }
 
     @action
-    setAdmin(isAdmin: boolean) {
-        const updatedUser = new User({ ...this.props, isAdmin }, this.store);
+    setRole(role: Role) {
+        const updatedUser = new User({ ...this.props, role }, this.store);
         this.store.update(updatedUser);
     }
 

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -36,16 +36,18 @@ export default class User {
     get hasElevatedAccess() {
         return this.accessLevel > 0;
     }
+    @computed
+    get isAdmin() {
+        return this.role === Role.ADMIN;
+    }
 
     @computed
     get isStudent() {
-        return STUDENT_USERNAME_PATTERN
-            ? new RegExp(STUDENT_USERNAME_PATTERN, 'i').test(this.email)
-            : !this.hasElevatedAccess;
+        return this.role === Role.STUDENT;
     }
 
     get isTeacher() {
-        return !this.isStudent;
+        return this.role === Role.TEACHER;
     }
 
     @computed

--- a/src/models/documents/CmsText.ts
+++ b/src/models/documents/CmsText.ts
@@ -61,7 +61,7 @@ class CmsText extends iDocument<DocumentType.CmsText> {
      */
     @computed
     get canEdit(): boolean {
-        return !!this.store.root.userStore.current?.isAdmin;
+        return !!this.store.root.userStore.current?.hasElevatedAccess;
     }
 }
 

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -95,7 +95,7 @@ const UserPage = observer(() => {
                         </>
                     )}
                 </DefinitionList>
-                {userStore.current?.isAdmin && (
+                {userStore.current?.hasElevatedAccess && (
                     <div>
                         <h2>User Tabelle</h2>
                         <div className={clsx(styles.userTable)}>
@@ -110,7 +110,7 @@ const UserPage = observer(() => {
                 )}
                 <h2>Account</h2>
                 <DefinitionList>
-                    {current?.isAdmin && (
+                    {current?.hasElevatedAccess && (
                         <>
                             <dt>Admin</dt>
                             <dd>

--- a/src/stores/CmsStore.ts
+++ b/src/stores/CmsStore.ts
@@ -209,7 +209,7 @@ export class CmsStore extends iStore<'logout' | `update-settings` | `load-settin
 
     @computed
     get canModifyActiveBranch() {
-        if (this.root.userStore.current?.isAdmin) {
+        if (this.root.userStore.current?.hasElevatedAccess) {
             return true;
         }
         return !this.isOnDefaultBranch;

--- a/src/stores/DocumentRootStore.ts
+++ b/src/stores/DocumentRootStore.ts
@@ -325,7 +325,7 @@ export class DocumentRootStore extends iStore {
 
     @action
     save(documentRoot: DocumentRoot<any>) {
-        if (!this.root.sessionStore.isLoggedIn || !this.root.userStore.current?.isAdmin) {
+        if (!this.root.sessionStore.isLoggedIn || !this.root.userStore.current?.hasElevatedAccess) {
             return Promise.resolve('error');
         }
 
@@ -341,7 +341,7 @@ export class DocumentRootStore extends iStore {
 
     @action
     destroy(documentRoot: DocumentRoot<any>) {
-        if (!this.root.sessionStore.isLoggedIn || !this.root.userStore.current?.isAdmin) {
+        if (!this.root.sessionStore.isLoggedIn || !this.root.userStore.current?.hasElevatedAccess) {
             return Promise.reject('error');
         }
         return this.withAbortController(`destroy-${documentRoot.id}`, (signal) => {

--- a/src/stores/DocumentStore.ts
+++ b/src/stores/DocumentStore.ts
@@ -219,7 +219,7 @@ class DocumentStore extends iStore<`delete-${string}`> {
         if (model.isDirty) {
             const { id } = model;
             const hasAdminAccess =
-                !!this.root.userStore.current?.isAdmin &&
+                !!this.root.userStore.current?.hasElevatedAccess &&
                 (model.authorId === this.root.userStore.current.id ||
                     ADMIN_EDITABLE_DOCUMENTS.includes(model.type));
             if (!model.canEdit && !hasAdminAccess) {
@@ -262,7 +262,7 @@ class DocumentStore extends iStore<`delete-${string}`> {
         if (!rootDoc || rootDoc.isDummy) {
             return Promise.resolve(undefined);
         }
-        const hasAccess = RWAccess.has(rootDoc.permission) || this.root.userStore.current?.isAdmin;
+        const hasAccess = RWAccess.has(rootDoc.permission) || this.root.userStore.current?.hasElevatedAccess;
         if (!hasAccess) {
             return Promise.resolve(undefined);
         }
@@ -302,7 +302,7 @@ class DocumentStore extends iStore<`delete-${string}`> {
 
     @action
     apiLoadDocumentsFrom(rootIds: string[]) {
-        if (!this.root.userStore.current?.isAdmin) {
+        if (!this.root.userStore.current?.hasElevatedAccess) {
             return Promise.resolve([]);
         }
         return this.withAbortController(`load-docs-${rootIds.join('::')}`, (sig) => {

--- a/src/stores/SocketDataStore.ts
+++ b/src/stores/SocketDataStore.ts
@@ -21,7 +21,7 @@ import { GroupPermission, UserPermission } from '@tdev-api/permission';
 import { Document, DocumentType } from '../api/document';
 import { NoneAccess } from '@tdev-models/helpers/accessPolicy';
 import { CmsSettings } from '@tdev-api/cms';
-import { PartialStudentGroup, StudentGroup as ApiStudentGroup } from '@tdev-api/studentGroup';
+import { StudentGroup as ApiStudentGroup } from '@tdev-api/studentGroup';
 import StudentGroup from '@tdev-models/StudentGroup';
 
 type TypedSocket = Socket<ServerToClientEvents, ClientToServerEvents>;
@@ -213,7 +213,7 @@ export class SocketDataStore extends iStore<'ping'> {
                 this.root.cmsStore.handleSettingsChange(record as CmsSettings);
                 break;
             case RecordType.StudentGroup:
-                const studentGroup = record as PartialStudentGroup;
+                const studentGroup = record as ApiStudentGroup;
                 this.root.studentGroupStore.handleUpdate(studentGroup);
                 break;
             default:

--- a/src/stores/SocketDataStore.ts
+++ b/src/stores/SocketDataStore.ts
@@ -214,8 +214,7 @@ export class SocketDataStore extends iStore<'ping'> {
                 break;
             case RecordType.StudentGroup:
                 const studentGroup = record as PartialStudentGroup;
-                if (Array.isArray(studentGroup.userIds)) {
-                }
+                this.root.studentGroupStore.handleUpdate(studentGroup);
                 break;
             default:
                 console.log('changedRecord', type, record);
@@ -245,6 +244,10 @@ export class SocketDataStore extends iStore<'ping'> {
                 break;
             case RecordType.StudentGroup:
                 const currentGroup = this.root.studentGroupStore.find(id);
+                if (this.root.userStore.current?.isAdmin && currentGroup?.userIds?.size) {
+                    /** admins always display all groups with some members, no matter what */
+                    return;
+                }
                 this.root.studentGroupStore.removeFromStore(currentGroup);
                 this.leaveRoom(id);
                 break;

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -154,6 +154,7 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
         return this.withAbortController(`members-rm-${studentGroup.id}-${user.id}`, async (signal) => {
             return apiRemoveUser(studentGroup.id, user.id, signal.signal).then(
                 action(({ data }) => {
+                    studentGroup.adminIds.delete(user.id);
                     studentGroup.userIds.delete(user.id);
                     return studentGroup;
                 })

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -10,7 +10,8 @@ import {
     addUser as apiAddUser,
     removeUser as apiRemoveUser,
     destroy as apiDestroy,
-    setAdminRole as apiSetAdminRole
+    setAdminRole as apiSetAdminRole,
+    PartialStudentGroup
 } from '../api/studentGroup';
 import User from '../models/User';
 
@@ -64,6 +65,35 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
             this.studentGroups.remove(old);
         }
         this.studentGroups.push(studentGroup);
+    }
+
+    @action
+    removeFromStore(studentGroup?: StudentGroup): StudentGroup | undefined {
+        /**
+         * Removes the model to the store
+         */
+        if (studentGroup && this.studentGroups.remove(studentGroup)) {
+            return studentGroup;
+        }
+    }
+    @action
+    handleUpdate(data: PartialStudentGroup) {
+        const model = this.find(data.id);
+        if (model && model.id) {
+            (['name', 'description', 'parentId'] as ('name' | 'description' | 'parentId')[]).forEach(
+                action((key) => {
+                    if (data[key] !== undefined && data[key] !== model[key]) {
+                        model[key] = data[key]!;
+                    }
+                })
+            );
+            if (Array.isArray(data.userIds)) {
+                model.userIds.replace(data.userIds);
+            }
+            if (Array.isArray(data.adminIds)) {
+                model.adminIds.replace(data.adminIds);
+            }
+        }
     }
 
     @action

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -47,11 +47,13 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
     @action
     create(name: string, description: string, parentId?: string) {
         return this.withAbortController(`create-${name}`, async (signal) => {
-            return apiCreate({ name, description, parentId }, signal.signal).then(({ data }) => {
-                const group = new StudentGroup(data, this);
-                this.studentGroups.push(group);
-                return group;
-            });
+            return apiCreate({ name, description, parentId }, signal.signal).then(
+                action(({ data }) => {
+                    const group = new StudentGroup(data, this);
+                    this.studentGroups.push(group);
+                    return group;
+                })
+            );
         });
     }
 
@@ -78,10 +80,12 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
     @action
     destroy(studentGroup: StudentGroup) {
         return this.withAbortController(`destroy-${studentGroup.id}`, async (signal) => {
-            return apiDestroy(studentGroup.id, signal.signal).then(({ data }) => {
-                this.studentGroups.remove(studentGroup);
-                return studentGroup;
-            });
+            return apiDestroy(studentGroup.id, signal.signal).then(
+                action(({ data }) => {
+                    this.studentGroups.remove(studentGroup);
+                    return studentGroup;
+                })
+            );
         });
     }
 

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -1,4 +1,4 @@
-import { action, observable } from 'mobx';
+import { action, computed, observable } from 'mobx';
 import { RootStore } from '@tdev-stores/rootStore';
 import { computedFn } from 'mobx-utils';
 import StudentGroup from '@tdev-models/StudentGroup';
@@ -33,6 +33,17 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
         },
         { keepAlive: true }
     );
+
+    @computed
+    get managedStudentGroups() {
+        if (!this.root.userStore.current) {
+            return [];
+        }
+        if (this.root.userStore.current.isAdmin) {
+            return this.studentGroups;
+        }
+        return this.studentGroups.filter((group) => group.isGroupAdmin);
+    }
 
     findByName = computedFn(
         function (this: StudentGroupStore, name?: string): StudentGroup | undefined {

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -11,7 +11,7 @@ import {
     removeUser as apiRemoveUser,
     destroy as apiDestroy,
     setAdminRole as apiSetAdminRole,
-    PartialStudentGroup
+    StudentGroup as ApiStudentGroup
 } from '../api/studentGroup';
 import User from '../models/User';
 
@@ -77,7 +77,7 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
         }
     }
     @action
-    handleUpdate(data: PartialStudentGroup) {
+    handleUpdate(data: ApiStudentGroup) {
         const model = this.find(data.id);
         if (!model) {
             return;
@@ -86,7 +86,7 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
             (key) => data[key] !== undefined && data[key] !== model[key]
         );
         if (needsReplace) {
-            return this.addToStore(new StudentGroup({ adminIds: [], userIds: [], ...data }, this));
+            return this.addToStore(new StudentGroup(data, this));
         }
         if (model && model.id) {
             if (data.parentId !== undefined && data.parentId !== model.parentId) {

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -79,14 +79,19 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
     @action
     handleUpdate(data: PartialStudentGroup) {
         const model = this.find(data.id);
+        if (!model) {
+            return;
+        }
+        const needsReplace = (['name', 'description'] as ('name' | 'description')[]).some(
+            (key) => data[key] !== undefined && data[key] !== model[key]
+        );
+        if (needsReplace) {
+            return this.addToStore(new StudentGroup({ adminIds: [], userIds: [], ...data }, this));
+        }
         if (model && model.id) {
-            (['name', 'description', 'parentId'] as ('name' | 'description' | 'parentId')[]).forEach(
-                action((key) => {
-                    if (data[key] !== undefined && data[key] !== model[key]) {
-                        model[key] = data[key]!;
-                    }
-                })
-            );
+            if (data.parentId !== undefined && data.parentId !== model.parentId) {
+                model.setParentId(data.parentId);
+            }
             if (Array.isArray(data.userIds)) {
                 model.userIds.replace(data.userIds);
             }

--- a/src/stores/StudentGroupStore.ts
+++ b/src/stores/StudentGroupStore.ts
@@ -9,7 +9,8 @@ import {
     update as apiUpdate,
     addUser as apiAddUser,
     removeUser as apiRemoveUser,
-    destroy as apiDestroy
+    destroy as apiDestroy,
+    setAdminRole as apiSetAdminRole
 } from '../api/studentGroup';
 import User from '../models/User';
 
@@ -104,6 +105,21 @@ export class StudentGroupStore extends iStore<`members-${string}`> {
             return apiRemoveUser(studentGroup.id, user.id, signal.signal).then(
                 action(({ data }) => {
                     studentGroup.userIds.delete(user.id);
+                    return studentGroup;
+                })
+            );
+        });
+    }
+    @action
+    setAdminRole(studentGroup: StudentGroup, user: User, isAdmin: boolean) {
+        return this.withAbortController(`members-admin-${studentGroup.id}-${user.id}`, async (signal) => {
+            return apiSetAdminRole(studentGroup.id, user.id, isAdmin, signal.signal).then(
+                action(({ data }) => {
+                    if (isAdmin) {
+                        studentGroup.adminIds.add(user.id);
+                    } else {
+                        studentGroup.adminIds.delete(user.id);
+                    }
                     return studentGroup;
                 })
             );

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -41,9 +41,9 @@ export class UserStore extends iStore<`update-${string}`> {
     }
 
     /**
-     * returns all users that are managed/administrated by the current user
-     * - through a group membership the current user is admin member of
-     * - when the current user is an admin
+     * returns all users that are managed/administrated by the current user, either:
+     * - when the current user is an admin, or
+     * - through a group admin-membership
      */
     @computed
     get managedUsers() {

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -1,5 +1,5 @@
 import { action, computed, observable } from 'mobx';
-import { User as UserProps, all as apiAll, currentUser, update as apiUpdate } from '@tdev-api/user';
+import { User as UserProps, all as apiAll, currentUser, update as apiUpdate, Role } from '@tdev-api/user';
 import { RootStore } from '@tdev-stores/rootStore';
 import User from '@tdev-models/User';
 import _ from 'lodash';
@@ -96,7 +96,7 @@ export class UserStore extends iStore<`update-${string}`> {
 
     @computed
     get viewedUserId() {
-        if (!this.current?.isAdmin) {
+        if (!this.current?.hasElevatedAccess) {
             return this.current?.id;
         }
         return this._viewedUserId || this.current?.id || this.root.sessionStore.userId;
@@ -109,7 +109,7 @@ export class UserStore extends iStore<`update-${string}`> {
 
     @action
     switchUser(userId: string | undefined) {
-        if (!this.current?.isAdmin || this._viewedUserId === userId) {
+        if (!this.current?.hasElevatedAccess || this._viewedUserId === userId) {
             return;
         }
         /**
@@ -156,7 +156,7 @@ export class UserStore extends iStore<`update-${string}`> {
                 const currentUser = this.addToStore(res.data);
                 if (currentUser) {
                     Storage.set('SessionStore', {
-                        user: { ...currentUser.props, isAdmin: false }
+                        user: { ...currentUser.props, role: Role.STUDENT }
                     });
                 }
                 return currentUser;

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -57,7 +57,12 @@ export class UserStore extends iStore<`update-${string}`> {
             return this.users;
         }
         return _.uniqBy(
-            this.root.studentGroupStore.studentGroups.flatMap((g) => [...g.students, ...g.admins]),
+            [
+                this.current,
+                ...this.root.studentGroupStore.studentGroups
+                    .filter((s) => s.isGroupAdmin)
+                    .flatMap((g) => [...g.students, ...g.admins])
+            ],
             'id'
         );
     }

--- a/src/stores/UserStore.ts
+++ b/src/stores/UserStore.ts
@@ -40,6 +40,28 @@ export class UserStore extends iStore<`update-${string}`> {
         }
     }
 
+    /**
+     * returns all users that are managed/administrated by the current user
+     * - through a group membership the current user is admin member of
+     * - when the current user is an admin
+     */
+    @computed
+    get managedUsers() {
+        if (!this.current) {
+            return [];
+        }
+        if (!this.current.hasElevatedAccess) {
+            return [this.current];
+        }
+        if (this.current.isAdmin) {
+            return this.users;
+        }
+        return _.uniqBy(
+            this.root.studentGroupStore.studentGroups.flatMap((g) => [...g.students, ...g.admins]),
+            'id'
+        );
+    }
+
     find = computedFn(
         function <T>(this: UserStore, id?: string): User | undefined {
             if (!id) {

--- a/src/stores/rootStore.ts
+++ b/src/stores/rootStore.ts
@@ -52,7 +52,7 @@ export class RootStore {
                 this.userStore.load();
                 this.studentGroupStore.load();
                 this.cmsStore.initialize();
-                if (user.isAdmin) {
+                if (user.hasElevatedAccess) {
                     this.adminStore.load();
                 }
             }


### PR DESCRIPTION
# User Roles and Group Admins
Related API-PR: https://github.com/GBSL-Informatik/teaching-api/pull/37
---
This enables us to use one streamlined backend for non-devs which can then manage their groups on their own.

- Users can be either `ADMIN`, `TEACHER` or (default) `STUDENT`
![image](https://github.com/user-attachments/assets/a4910656-1456-43c2-a3c4-34f280f21d72)
- StudentGroups can have now Admins - Group-Admins (Teachers/Admins) can
  - Add Students to their groups
  - See student's work (Switch view)
- Changes to the StudentGroup are now live-updated with SocketIo...
- Users added/removed to a new group will join/leave this group immediately