### PR TITLE
critical: fix overwriting code blocks

### DIFF
--- a/src/components/documents/CodeEditor/index.tsx
+++ b/src/components/documents/CodeEditor/index.tsx
@@ -26,7 +26,7 @@ export const CodeEditor = observer((props: Props) => {
     const id = props.slim ? undefined : props.id;
     const script = useFirstMainDocument(id, new ScriptMeta(props));
     React.useEffect(() => {
-        if (script) {
+        if (script && script.meta?.slim) {
             script.setCode(props.code);
         }
     }, [script, props.code]);


### PR DESCRIPTION
in #146 an ugly bug was introduced, that always saved a loaded code-script with the initial value - what resulted in overwriting user code.

However, this should always be prevented and the dynamic behavior should be applicable only when it is a `slim` code block.