### PR TITLE
Revert bryRunner switch from setTimeout to microtask.

### DIFF
--- a/src/components/documents/CodeEditor/utils/bryRunner.ts
+++ b/src/components/documents/CodeEditor/utils/bryRunner.ts
@@ -30,11 +30,11 @@ export const runCode = (
      * ensure that the script is executed after the current event loop.
      * Otherwise, the brython script will not be able to access the graphics output.
      */
-    scheduleMicrotask(() => {
+    setTimeout(() => {
         (window as any).__BRYTHON__.runPythonSource(src, {
             pythonpath: router === 'hash' ? [] : [libDir],
             cache: cache
         });
-    });
+    }, 0);
     return src;
 };

--- a/src/components/documents/CodeEditor/utils/bryRunner.ts
+++ b/src/components/documents/CodeEditor/utils/bryRunner.ts
@@ -1,7 +1,6 @@
 import { RouterType } from '@docusaurus/types';
 import { DOM_ELEMENT_IDS } from '../constants';
 import { sanitizePyScript } from './helpers';
-import scheduleMicrotask from '@tdev-components/util/scheduleMicrotask';
 
 export const runCode = (
     code: string,


### PR DESCRIPTION
I don't yet fully understand the behavior of microtasks with respect to the event loop, but it seems to differ from `setTimeout`. Judging from the comment in `bryRunner.ts#28`, the brython script seems to be unable to access the graphics output with the `scheduleMicrotask` solution.

![image](https://github.com/user-attachments/assets/a7a8e794-f35d-4468-a749-db3eaa567ccf)
![image](https://github.com/user-attachments/assets/2b2b5fc0-ecd3-498c-b913-0ce29447c63a)

This PR reverts to the previous `setTimeout` solution.