### PR TITLE
Fix partially covered PDF download button.

### DIFF
--- a/src/components/PdfViewer/PdfViewer.module.scss
+++ b/src/components/PdfViewer/PdfViewer.module.scss
@@ -16,6 +16,7 @@
             opacity: 0.2;
             padding: 0.2em 1em;
             padding-bottom: 0;
+            z-index: 10;
         }
         &:hover {
             .download {


### PR DESCRIPTION
PDF download button was hard to click because it was partially covered. Fixed it by adding a z-index.