### PR TITLE
Suggestion: Change sync status icon and color scheme.

### DIFF
--- a/src/components/SyncStatus/index.tsx
+++ b/src/components/SyncStatus/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react-lite';
 import { ApiState } from '@tdev-stores/iStore';
 import Icon from '@mdi/react';
-import { mdiCheckCircle, mdiCloseCircle, mdiSync } from '@mdi/js';
+import { mdiCloudCheckVariantOutline, mdiCloseCircle, mdiSync  } from '@mdi/js';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props {
@@ -23,7 +23,7 @@ const SyncStatus = observer((props: Props) => {
                 <Icon
                     path={mdiSync}
                     spin={-2}
-                    color="var(--ifm-color-primary)"
+                    color="var(--ifm-color-secondary)"
                     size={size}
                     className={props.className}
                 />
@@ -31,8 +31,8 @@ const SyncStatus = observer((props: Props) => {
         case ApiState.SUCCESS:
             return (
                 <Icon
-                    path={mdiCheckCircle}
-                    color="var(--ifm-color-success)"
+                    path={mdiCloudCheckVariantOutline}
+                    color="var(--ifm-color-primary)"
                     size={size}
                     className={props.className}
                 />

--- a/src/components/SyncStatus/index.tsx
+++ b/src/components/SyncStatus/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react-lite';
 import { ApiState } from '@tdev-stores/iStore';
 import Icon from '@mdi/react';
-import { mdiCloudCheckVariantOutline, mdiCloseCircle, mdiSync  } from '@mdi/js';
+import { mdiCloudCheckVariantOutline, mdiCloseCircle, mdiSync } from '@mdi/js';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props {

--- a/src/components/SyncStatus/index.tsx
+++ b/src/components/SyncStatus/index.tsx
@@ -23,7 +23,7 @@ const SyncStatus = observer((props: Props) => {
                 <Icon
                     path={mdiSync}
                     spin={-2}
-                    color="var(--ifm-color-secondary)"
+                    color="var(--sync-status-syncinc-color)"
                     size={size}
                     className={props.className}
                 />
@@ -32,7 +32,7 @@ const SyncStatus = observer((props: Props) => {
             return (
                 <Icon
                     path={mdiCloudCheckVariantOutline}
-                    color="var(--ifm-color-primary)"
+                    color="var(--sync-status-success-color)"
                     size={size}
                     className={props.className}
                 />
@@ -41,7 +41,7 @@ const SyncStatus = observer((props: Props) => {
             return (
                 <Icon
                     path={mdiCloseCircle}
-                    color="var(--ifm-color-danger)"
+                    color="var(--sync-status-error-color)"
                     size={size}
                     className={props.className}
                 />

--- a/src/components/SyncStatus/index.tsx
+++ b/src/components/SyncStatus/index.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { observer } from 'mobx-react-lite';
 import { ApiState } from '@tdev-stores/iStore';
 import Icon from '@mdi/react';
-import { mdiCloudCheckVariantOutline, mdiCloseCircle, mdiSync } from '@mdi/js';
+import { mdiContentSaveCheckOutline, mdiContentSaveOffOutline, mdiSync } from '@mdi/js';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props {
@@ -23,7 +23,7 @@ const SyncStatus = observer((props: Props) => {
                 <Icon
                     path={mdiSync}
                     spin={-2}
-                    color="var(--sync-status-syncinc-color)"
+                    color="var(--tdev-sync-status-syncinc-color)"
                     size={size}
                     className={props.className}
                 />
@@ -31,8 +31,8 @@ const SyncStatus = observer((props: Props) => {
         case ApiState.SUCCESS:
             return (
                 <Icon
-                    path={mdiCloudCheckVariantOutline}
-                    color="var(--sync-status-success-color)"
+                    path={mdiContentSaveCheckOutline}
+                    color="var(--tdev-sync-status-success-color)"
                     size={size}
                     className={props.className}
                 />
@@ -40,8 +40,8 @@ const SyncStatus = observer((props: Props) => {
         case ApiState.ERROR:
             return (
                 <Icon
-                    path={mdiCloseCircle}
-                    color="var(--sync-status-error-color)"
+                    path={mdiContentSaveOffOutline}
+                    color="var(--tdev-sync-status-error-color)"
                     size={size}
                     className={props.className}
                 />

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -23,6 +23,9 @@
     --ifm-color-violet: #8957e5;
     --ifm-color-boxed: #3348b5;
     --prism-background-color: #f6f8fa;
+    --sync-status-syncing-color: var(--ifm-color-secondary);
+    --sync-status-success-color: var(--ifm-color-primary);
+    --sync-status-error-color: var(--ifm-color-danger);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */

--- a/src/css/custom.scss
+++ b/src/css/custom.scss
@@ -23,9 +23,9 @@
     --ifm-color-violet: #8957e5;
     --ifm-color-boxed: #3348b5;
     --prism-background-color: #f6f8fa;
-    --sync-status-syncing-color: var(--ifm-color-secondary);
-    --sync-status-success-color: var(--ifm-color-primary);
-    --sync-status-error-color: var(--ifm-color-danger);
+    --tdev-sync-status-syncing-color: var(--ifm-color-secondary);
+    --tdev-sync-status-success-color: var(--ifm-color-primary);
+    --tdev-sync-status-error-color: var(--ifm-color-danger);
 }
 
 /* For readability concerns, you should choose a lighter palette in dark mode. */


### PR DESCRIPTION
Students often misinterpret the green "changes saved checkmark" sync status icon as "my answer is correct". As a result, they don't click the button to have their answer checked and might not realize that they made a mistake.

Suggestion: Change to a different icon, use color-secondary for "syncing" and use "color-primary" for success. Since these are signal colors, they probably shouldn't depend on a custom color scheme (color-primary, color-secondary), so this PR also moves that definition to a set of custom vars in `custom.scss`.

Try it out [here (String answer)](https://deploy-preview-159--teaching-dev.netlify.app/docs/gallery/persistable-documents/answer/string-answers/) or [here (Quill)](https://deploy-preview-159--teaching-dev.netlify.app/docs/gallery/persistable-documents/answer/quill-v2/).

## TODO
- [ ] Prefix CSS vars with `--tdev`.
- [ ] Consider using a different icon.
