### PR TITLE
fix: color stacked icons

### DIFF
--- a/src/components/MdiSelector/index.tsx
+++ b/src/components/MdiSelector/index.tsx
@@ -1,4 +1,4 @@
-import React, { useId } from 'react';
+import React from 'react';
 import clsx from 'clsx';
 import styles from './styles.module.scss';
 import Icon from '@mdi/react';

--- a/src/components/shared/CopyBadge/index.tsx
+++ b/src/components/shared/CopyBadge/index.tsx
@@ -62,7 +62,7 @@ const CopyBadge = (props: Props) => {
         >
             {props.label || props.value}
             <span className={clsx(styles.copyIcon)}>
-                <Stack size={props.size || 0.7}>
+                <Stack size={props.size || 0.7} color={null}>
                     <Icon path={mdiCircle} size={props.size || 0.75} color={'var(--ifm-color-secondary)'} />
                     <Icon path={CopyIcon[copyState]} size={props.size || 0.6} color={CopyColor[copyState]} />
                 </Stack>


### PR DESCRIPTION
closes #160

ensure using `color={null}` for icon stacks