### PR TITLE
Fix/hydration-errors

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -501,7 +501,22 @@ const config: Config = {
             }
           }
       }
-    }
+    },
+    () => {
+      return {
+        name: 'socketio-no-dep-warnings',
+        configureWebpack(config, isServer, {currentBundler}) {
+          return {
+            plugins: [
+              new currentBundler.instance.DefinePlugin({
+                'process.env.WS_NO_BUFFER_UTIL': JSON.stringify('true'),
+                'process.env.WS_NO_UTF_8_VALIDATE': JSON.stringify('true')
+              }),
+            ]
+          }
+        }
+      }
+    },
   ],
   themes: [
     [

--- a/src/api/OfflineApi.ts
+++ b/src/api/OfflineApi.ts
@@ -107,7 +107,9 @@ export default class OfflineApi {
         }
     };
     constructor() {
-        console.log('OfflineApi: created');
+        if (LOG_REQUESTS) {
+            console.log('OfflineApi: created');
+        }
     }
     // Method to handle POST requests
     async post<T = any>(url: string, data: T, ...config: any): AxiosPromise<T> {

--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -7,10 +7,12 @@ import { BACKEND_URL } from '@tdev/authConfig';
 import Icon from '@mdi/react';
 import { mdiCheckCircle, mdiCloseCircle, mdiConnection } from '@mdi/js';
 import Button from '@tdev-components/shared/Button';
+import { useIsLive } from '@tdev-hooks/useIsLive';
 
 const HomepageFeatures = observer(() => {
     const socketStore = useStore('socketStore');
     const userStore = useStore('userStore');
+    const isLive = useIsLive();
     return (
         <section className={styles.features}>
             <div className="container">
@@ -20,7 +22,7 @@ const HomepageFeatures = observer(() => {
                     <dd>{BACKEND_URL}</dd>
                     <dt>Connected?</dt>
                     <dd>
-                        {socketStore.isLive ? (
+                        {isLive ? (
                             <span>
                                 <Icon path={mdiCheckCircle} size={0.8} color="var(--ifm-color-success)" />{' '}
                                 Live
@@ -32,7 +34,7 @@ const HomepageFeatures = observer(() => {
                             </span>
                         )}
                     </dd>
-                    {socketStore.isLive && (
+                    {isLive && (
                         <>
                             <dt>Clients</dt>
                             <dd>{socketStore.connectedClients.get(userStore.viewedUser?.id ?? '') ?? 0}</dd>
@@ -47,7 +49,7 @@ const HomepageFeatures = observer(() => {
                                 socketStore.resetUserData();
                                 socketStore.connect();
                             }}
-                            disabled={socketStore.isLive}
+                            disabled={isLive}
                             color="blue"
                         />
                     </dd>
@@ -56,7 +58,7 @@ const HomepageFeatures = observer(() => {
                             icon={mdiCloseCircle}
                             text="Disconnect"
                             onClick={() => socketStore.disconnect()}
-                            disabled={!socketStore.isLive}
+                            disabled={!isLive}
                             color="red"
                         />
                     </dd>

--- a/src/components/Loader/index.tsx
+++ b/src/components/Loader/index.tsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 import styles from './styles.module.scss';
 import Icon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props {
     label?: string;
@@ -15,6 +16,7 @@ interface Props {
 }
 
 const Loader = (props: Props) => {
+    const isBrowser = useIsBrowser();
     return (
         <div
             className={clsx(
@@ -25,7 +27,7 @@ const Loader = (props: Props) => {
             )}
             title={props.title}
         >
-            <Icon path={mdiLoading} spin size={props.size || 1} className={styles.icon} />
+            <Icon path={mdiLoading} spin={isBrowser} size={props.size || 1} className={styles.icon} />
             {!props.noLabel && (
                 <span className={clsx('badge', styles.badge)}>{props.label || 'Laden...'}</span>
             )}

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -16,11 +16,10 @@ const AccountSwitcher = observer(() => {
     const userStore = useStore('userStore');
     const location = useLocation();
 
-    const klass = location.pathname.split('/')[1];
-
     if (!isBrowser || !userStore.current?.hasElevatedAccess) {
         return null;
     }
+    const klass = location.pathname.split('/')[1];
     return (
         <>
             {userStore.isUserSwitched && (

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -9,6 +9,7 @@ import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import Icon from '@mdi/react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import { useIsLive } from '@tdev-hooks/useIsLive';
 const { NO_AUTH } = siteConfig.customFields as { NO_AUTH?: boolean };
 
 const LoginButton = () => {
@@ -20,8 +21,13 @@ const LoginProfileButton = observer(() => {
     const userStore = useStore('userStore');
     const sessionStore = useStore('sessionStore');
     const socketStore = useStore('socketStore');
+    const isLive = useIsLive();
 
-    if (!isBrowser || !(sessionStore.isLoggedIn || NO_AUTH)) {
+    if (!isBrowser) {
+        return null;
+    }
+
+    if (!sessionStore.isLoggedIn && !NO_AUTH) {
         return <LoginButton />;
     }
     return (
@@ -41,7 +47,7 @@ const LoginProfileButton = observer(() => {
                     (
                         userStore.isUserSwitched
                             ? (socketStore.connectedClients.get(userStore.viewedUser?.id || ' ') || 1) - 1 > 0
-                            : socketStore.isLive
+                            : isLive
                     )
                         ? 'var(--ifm-color-success)'
                         : 'var(--ifm-color-danger)'

--- a/src/components/Navbar/RequestTarget/index.tsx
+++ b/src/components/Navbar/RequestTarget/index.tsx
@@ -3,32 +3,18 @@ import clsx from 'clsx';
 
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
-import {
-    mdiAccountCircleOutline,
-    mdiAccountSwitch,
-    mdiHomeAccount,
-    mdiLaptop,
-    mdiShieldAccount,
-    mdiTarget,
-    mdiTargetAccount
-} from '@mdi/js';
+import { mdiLaptop } from '@mdi/js';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import Popup from 'reactjs-popup';
 import _ from 'lodash';
-import { useLocation } from '@docusaurus/router';
-import { Confirm } from '@tdev-components/shared/Button/Confirm';
 import NavSetTargetRequest from '@tdev-components/Admin/ActionRequest/NavSetTargetRequest';
 
 const ReguestTarget = observer(() => {
     const isBrowser = useIsBrowser();
     const userStore = useStore('userStore');
     const studentGroupStore = useStore('studentGroupStore');
-    const socketStore = useStore('socketStore');
-    const location = useLocation();
-
-    const klass = location.pathname.split('/')[1];
 
     if (!isBrowser || !userStore.current?.hasElevatedAccess) {
         return null;

--- a/src/components/PdfViewer/PdfViewer.tsx
+++ b/src/components/PdfViewer/PdfViewer.tsx
@@ -9,6 +9,7 @@ import Icon from '@mdi/react';
 import { mdiArrowLeftCircle, mdiArrowRightCircle, mdiDownload } from '@mdi/js';
 import Button from '@tdev-components/shared/Button';
 import scheduleMicrotask from '@tdev-components/util/scheduleMicrotask';
+import Loader from '@tdev-components/Loader';
 
 export interface Props {
     file: string | { data: Uint8Array; url?: string } | { url: string };
@@ -116,7 +117,7 @@ const PdfViewer = (props: Props) => {
     };
 
     if (!inBrowser) {
-        return <div>Loading...</div>;
+        return <Loader />;
     }
 
     return (

--- a/src/components/PdfViewer/index.tsx
+++ b/src/components/PdfViewer/index.tsx
@@ -14,12 +14,13 @@ import Loader from '@tdev-components/Loader';
 
 export const PdfViewer = observer((props: Props) => {
     const [pdfViewer, setPdfViewer] = React.useState<{ default: typeof PdfViewerType }>();
+    const isBrowser = useIsBrowser();
     React.useEffect(() => {
         import('./PdfViewer').then((pdfViewer) => {
             setPdfViewer(pdfViewer);
         });
     }, []);
-    if (!useIsBrowser() || !pdfViewer) {
+    if (!isBrowser || !pdfViewer) {
         return <Loader />;
     }
 

--- a/src/components/documents/CmsText/Code/index.tsx
+++ b/src/components/documents/CmsText/Code/index.tsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import CmsActions from '../CmsActions';
 import { CmsTextEntries } from '../WithCmsText';
 import { useStore } from '@tdev-hooks/useStore';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props extends DefaultCmsProps {
     codeBlockProps?: CodeBlockProps;
@@ -19,8 +20,12 @@ const CmsCode = observer((props: Props) => {
     const contextId = name ? React.useContext(CmsTextContext)?.entries[name] : undefined;
     const documentRootId = id || contextId;
     const cmsText = useFirstCmsTextDocumentIfExists(documentRootId);
+    const isBrowser = useIsBrowser();
     const actionEntries =
         showActions && documentRootId ? ({ [documentRootId]: documentRootId } as CmsTextEntries) : undefined;
+    if (!isBrowser) {
+        return null;
+    }
     if (!cmsText || (!cmsText.canDisplay && !userStore.isUserSwitched)) {
         return actionEntries ? (
             <CmsActions entries={actionEntries} className={clsx(styles.codeBlock)} mode="code" />

--- a/src/components/documents/CmsText/Link/index.tsx
+++ b/src/components/documents/CmsText/Link/index.tsx
@@ -9,6 +9,7 @@ import { CmsTextEntries } from '../WithCmsText';
 import { useStore } from '@tdev-hooks/useStore';
 import Link from '@docusaurus/Link';
 import DivSpanWrapper from '@tdev-components/shared/DivSpanWrapper';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props extends DefaultCmsProps {
     children?: React.ReactNode;
@@ -21,6 +22,10 @@ const CmsLink = observer((props: Props) => {
     const contextId = name ? React.useContext(CmsTextContext)?.entries[name] : undefined;
     const documentRootId = id || contextId;
     const cmsText = useFirstCmsTextDocumentIfExists(documentRootId);
+    const isBrowser = useIsBrowser();
+    if (!isBrowser) {
+        return null;
+    }
     const actionEntries =
         showActions && documentRootId ? ({ [documentRootId]: documentRootId } as CmsTextEntries) : undefined;
 

--- a/src/components/documents/CmsText/WithCmsText/index.tsx
+++ b/src/components/documents/CmsText/WithCmsText/index.tsx
@@ -3,6 +3,7 @@ import { observer } from 'mobx-react-lite';
 import CmsActions from '../CmsActions';
 import styles from './styles.module.scss';
 import clsx from 'clsx';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export type Name = string & { __nameBrand: 'Name' };
 export type DocumentRootId = string & { __nameBrand: 'DocumentRootId' };
@@ -18,9 +19,13 @@ interface Props {
 
 const WithCmsText = observer((props: Props) => {
     const { entries, hideActions, children } = props;
+    const isBrowser = useIsBrowser();
     const allDocumentsAvailable = Object.values(entries)
         .map((documentRootId) => !!useFirstCmsTextDocumentIfExists(documentRootId))
         .every(Boolean);
+    if (!isBrowser) {
+        return null;
+    }
 
     return allDocumentsAvailable ? (
         <CmsTextContext.Provider value={{ entries }}>

--- a/src/components/documents/CmsText/index.tsx
+++ b/src/components/documents/CmsText/index.tsx
@@ -6,6 +6,7 @@ import { CmsTextEntries } from './WithCmsText';
 import { useStore } from '@tdev-hooks/useStore';
 import clsx from 'clsx';
 import Popup from 'reactjs-popup';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export interface Props {
     id?: string;
@@ -31,9 +32,13 @@ export const EmptyContent = (props: { className?: string }) => {
 const CmsText = observer((props: Props) => {
     const { id, name, showActions } = props;
     const contextId = name ? React.useContext(CmsTextContext)?.entries[name] : undefined;
+    const isBrowser = useIsBrowser();
     const userStore = useStore('userStore');
     const rootId = id || contextId;
     const cmsText = useFirstCmsTextDocumentIfExists(rootId);
+    if (!isBrowser) {
+        return null;
+    }
     if (!cmsText || (!cmsText.canDisplay && !userStore.isUserSwitched)) {
         return showActions && rootId ? (
             <CmsActions entries={{ [rootId]: rootId } as CmsTextEntries} mode={props.mode} />

--- a/src/components/documents/CodeEditor/SvgEditor/index.tsx
+++ b/src/components/documents/CodeEditor/SvgEditor/index.tsx
@@ -13,6 +13,7 @@ import CodeBlock from '@theme/CodeBlock';
 import Card from '@tdev-components/shared/Card';
 import Button from '@tdev-components/shared/Button';
 import { extractCodeBlockProps } from '@tdev/theme/CodeBlock/extractCodeBlockProps';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export interface Props extends Omit<MetaProps, 'live_jsx' | 'live_py' | 'title'> {
     title?: string;
@@ -41,7 +42,8 @@ const SvgEditor = observer((props: Props) => {
         new ScriptMeta({ title: 'SVG', ...props, code: getInitialCode(props), lang: 'svg' })
     );
     const doc = useFirstMainDocument(id, meta);
-    if (!ExecutionEnvironment.canUseDOM || !doc) {
+    const isBrowser = useIsBrowser();
+    if (!isBrowser || !doc) {
         return <CodeBlock language="svg">{props.code}</CodeBlock>;
     }
     if (!doc.canDisplay && props.id) {

--- a/src/components/documents/Excalidoc/WithCodeEditor/index.tsx
+++ b/src/components/documents/Excalidoc/WithCodeEditor/index.tsx
@@ -57,7 +57,6 @@ const ExcalidocWithCodeEditor = observer((props: Props) => {
                                 elements.forEach((element: { version: number }) => {
                                     element.version = element.version + 1;
                                 });
-                                console.log(elements);
                                 doc.setData(
                                     {
                                         image: '',

--- a/src/components/documents/QuillV2/index.tsx
+++ b/src/components/documents/QuillV2/index.tsx
@@ -38,12 +38,13 @@ type QuillProps = Props & {
 export const QuillV2Component = observer((props: QuillProps) => {
     const [quill, setQuill] = React.useState<{ default: typeof QuillV2Type }>();
     const { quillDoc } = props;
+    const isBrowser = useIsBrowser();
     React.useEffect(() => {
         import('./QuillV2').then((quill) => {
             setQuill(quill);
         });
     }, []);
-    if (!useIsBrowser() || !quill || !quillDoc) {
+    if (!isBrowser || !quill || !quillDoc) {
         return <div>{quillDoc.meta.default || quillDoc.meta.placeholder || '✍️ Antwort...'}</div>;
     }
 

--- a/src/components/documents/Restricted/index.tsx
+++ b/src/components/documents/Restricted/index.tsx
@@ -9,6 +9,7 @@ import { useStore } from '@tdev-hooks/useStore';
 import PermissionsPanel from '@tdev-components/PermissionsPanel';
 import { NoneAccess } from '@tdev-models/helpers/accessPolicy';
 import AccessBadge from '@tdev-components/PermissionsPanel/AccessBadge';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props extends MetaInit {
     id: string;
@@ -18,15 +19,19 @@ interface Props extends MetaInit {
 
 const Restricted = observer((props: Props) => {
     const [meta] = React.useState(new ModelMeta(props));
+    const isBrowser = useIsBrowser();
+    const userStore = useStore('userStore');
     const docRoot = useDocumentRoot(props.id, meta, false, {
         access: props.access || Access.None_DocumentRoot
     });
-    const userStore = useStore('userStore');
+    if (!isBrowser) {
+        return null;
+    }
     if (!docRoot || docRoot.isDummy) {
         if (!!userStore.current) {
             return <Loader />;
         } else {
-            return <div></div>;
+            return null;
         }
     }
     return (
@@ -34,9 +39,7 @@ const Restricted = observer((props: Props) => {
             {!NoneAccess.has(props.access) &&
             (!NoneAccess.has(docRoot.permission) || userStore.current?.hasElevatedAccess) ? (
                 <div>{props.children}</div>
-            ) : (
-                <div></div>
-            )}
+            ) : null}
             <div className={styles.adminControls}>
                 {userStore.current?.hasElevatedAccess && <PermissionsPanel documentRootId={docRoot.id} />}
                 {userStore.current?.hasElevatedAccess && (

--- a/src/components/documents/String/index.tsx
+++ b/src/components/documents/String/index.tsx
@@ -10,6 +10,7 @@ import Icon from '@mdi/react';
 import SyncStatus from '@tdev-components/SyncStatus';
 import { Source } from '@tdev-models/iDocument';
 import { mdiCheckCircle, mdiCloseCircle, mdiFlashTriangle, mdiHelpCircleOutline } from '@mdi/js';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 interface Props extends MetaInit {
     id: string;
@@ -103,13 +104,14 @@ const String = observer((props: Props) => {
     const stateIconsPosition =
         props.stateIconsPosition ||
         (['text', 'url', 'email', 'tel'].includes(inputType) ? 'inside' : 'outside');
+    const isBrowser = useIsBrowser();
     React.useEffect(() => {
         if (doc) {
             doc.checkAnswer();
         }
     }, [doc]);
 
-    if (!doc) {
+    if (!doc || !isBrowser) {
         return <Loader />;
     }
     const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/components/documents/TaskState/TaskStateOverview/index.tsx
+++ b/src/components/documents/TaskState/TaskStateOverview/index.tsx
@@ -6,13 +6,14 @@ import { observer } from 'mobx-react-lite';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import { mdiCheckboxMultipleMarkedCircle } from '@mdi/js';
-import { Access, StateType } from '@tdev-api/document';
+import { StateType } from '@tdev-api/document';
 import Icon from '@mdi/react';
 import Popup from 'reactjs-popup';
 import TaskStateList from './TaskStateList';
 import { RWAccess } from '@tdev-models/helpers/accessPolicy';
 import _ from 'lodash';
 import PageStudentGroupFilter from '@tdev-components/shared/PageStudentGroupFilter';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export const mdiColor: { [key in StateType]: string } = {
     checked: '--ifm-color-success',
@@ -46,12 +47,12 @@ const OverviewIcon = (props: OverviewIconProps) => {
 };
 
 const TaskStateOverview = observer(() => {
+    const isBrowser = useIsBrowser();
     const userStore = useStore('userStore');
     const pageStore = useStore('pageStore');
-    const studentGroupStore = useStore('studentGroupStore');
     const currentUser = userStore.current;
     const currentPage = pageStore.current;
-    if (!currentUser || !currentPage) {
+    if (!isBrowser || !currentUser || !currentPage) {
         return null;
     }
     const taskStates = currentPage.taskStates.filter((ts) => RWAccess.has(ts.root?.permission)) || [];

--- a/src/components/shared/Button/index.tsx
+++ b/src/components/shared/Button/index.tsx
@@ -5,6 +5,7 @@ import styles from './styles.module.scss';
 import Link from '@docusaurus/Link';
 import { Color, getButtonColorClass } from '../Colors';
 import Icon from '@mdi/react';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 
 export const POPUP_BUTTON_STYLE = clsx(
     styles.button,
@@ -73,8 +74,9 @@ export const extractSharedProps = (props: Base) => {
 
 export const ButtonIcon = (props: Props) => {
     let icon = props.icon;
+    const isBrowser = useIsBrowser();
     if (typeof icon === 'string') {
-        icon = <Icon path={icon} size={props.size || 1} spin={props.spin} />;
+        icon = <Icon path={icon} size={props.size || 1} spin={isBrowser && props.spin} />;
     }
     return <>{icon && <span className={clsx(styles.icon, props.className)}>{icon}</span>}</>;
 };

--- a/src/hooks/useIsLive.ts
+++ b/src/hooks/useIsLive.ts
@@ -1,0 +1,8 @@
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import { useStore } from '@tdev-hooks/useStore';
+
+export const useIsLive = () => {
+    const socketStore = useStore('socketStore');
+    const isBrowser = useIsBrowser();
+    return isBrowser && socketStore.isLive;
+};

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -19,9 +19,12 @@ import NavReloadRequest from '@tdev-components/Admin/ActionRequest/NavReloadRequ
 import Storage from '@tdev-stores/utils/Storage';
 import { logout } from '@tdev-api/user';
 import SelectInput from '@tdev-components/shared/SelectInput';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+import { useIsLive } from '@tdev-hooks/useIsLive';
 
-const { NO_AUTH, TEST_USERNAMES } = siteConfig.customFields as {
+const { NO_AUTH, OFFLINE_API, TEST_USERNAMES } = siteConfig.customFields as {
     NO_AUTH?: boolean;
+    OFFLINE_API?: boolean;
     TEST_USERNAMES: string[];
 };
 
@@ -35,13 +38,18 @@ const LeftAlign = (text: String) => {
 };
 
 const UserPage = observer(() => {
+    const isBrowser = useIsBrowser();
     const sessionStore = useStore('sessionStore');
     const userStore = useStore('userStore');
     const socketStore = useStore('socketStore');
     const groupStore = useStore('studentGroupStore');
     const isAuthenticated = useIsAuthenticated();
     const { inProgress } = useMsal();
+    const isLive = useIsLive();
     const { viewedUser, current } = userStore;
+    if (OFFLINE_API && !isBrowser) {
+        return <Loader />;
+    }
     if (
         !NO_AUTH &&
         ((sessionStore.currentUserId && !sessionStore.isLoggedIn) || inProgress !== InteractionStatus.None)
@@ -68,11 +76,9 @@ const UserPage = observer(() => {
                         <Icon
                             path={mdiCircle}
                             size={0.7}
-                            color={
-                                socketStore.isLive ? 'var(--ifm-color-success)' : 'var(--ifm-color-danger)'
-                            }
+                            color={isLive ? 'var(--ifm-color-success)' : 'var(--ifm-color-danger)'}
                         />{' '}
-                        {socketStore.isLive ? 'Ja' : 'Nein'}
+                        {isLive ? 'Ja' : 'Nein'}
                     </dd>
                     {viewedUser && (
                         <>

--- a/src/stores/utils/SessionStorage.ts
+++ b/src/stores/utils/SessionStorage.ts
@@ -1,6 +1,7 @@
 import siteConfig from '@generated/docusaurus.config';
 import _ from 'lodash';
 import MemoryStorage from './MemoryStorage';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export const StorageKey = Object.freeze({
     GithubToken: _.upperFirst(_.camelCase(`GithubToken${siteConfig.projectName || ''}`))
@@ -20,7 +21,9 @@ class SessionStorage {
             sessionStorage.removeItem('test');
             this.interface = sessionStorage;
         } catch (_err) {
-            console.log('sessionStorage not available, falling back to memory storage');
+            if (ExecutionEnvironment.canUseDOM) {
+                console.log('sessionStorage not available, falling back to memory storage');
+            }
             this.interface = new MemoryStorage();
         }
     }

--- a/src/stores/utils/Storage.ts
+++ b/src/stores/utils/Storage.ts
@@ -2,6 +2,7 @@ import { User } from '@tdev-api/user';
 import siteConfig from '@generated/docusaurus.config';
 import _ from 'lodash';
 import MemoryStorage from './MemoryStorage';
+import ExecutionEnvironment from '@docusaurus/ExecutionEnvironment';
 
 export type PersistedData = {
     user?: User;
@@ -27,7 +28,9 @@ class Storage {
             localStorage.removeItem('test');
             this.interface = localStorage;
         } catch (_err) {
-            console.log('localStorage not available, falling back to memory storage');
+            if (ExecutionEnvironment.canUseDOM) {
+                console.log('localStorage not available, falling back to memory storage');
+            }
             this.interface = new MemoryStorage();
         }
     }


### PR DESCRIPTION
The webpage had various rehydration errors (RHE) - this is shown on a fresh load of the webpage in the console and looks something like this

```
clientEntry.js:31  Docusaurus React Root onRecoverableError: Error: Minified React error #418; visit https://react.dev/errors/418?args[]= for the full message or use the non-minified dev environment for full errors and additional helpful warnings.
    at r_ (react-dom-client.production.js:2667:15)
    at CU (react-dom-client.production.js:7445:17)
    at uH (react-dom-client.production.js:10855:14)
    at react-dom-client.production.js:10852:5
    at react-dom-client.production.js:10853:1
    at a8 (react-dom-client.production.js:10849:1)
    at uN (react-dom-client.production.js:11626:3)
    at MessagePort.k (scheduler.production.js:151:44) {componentStack: '\n    at span (<anonymous>)\n    at https://teaching…bsl.website/assets/js/main.5269526d.js:1:3282464)'}
```

This happens when during rehydration the static content does not match what was compiled on the server. This could lead to weird reordering-errors.

- The Loader component used `spin` directly - so it begins to spin and when the rehydration happens, the icon is not in the same orientation anymore = RHE
- Same for the button in SPIN-State
- When the cached user is loaded from the localstore, it could happen that the stores were loaded **before** the first render and thus the state changed before-hand. The needed various `useIsBrowser` checks
- The `socketStore.isLive` tended to be a root cause of RHE, because the state could flip to `live` before the first render...


Additionally, the PR addresses verbose logging during build time and
- removes the socketio warnings, that the node-only dep's are not installed for web by adding ENV-Variables (this is the change in docusaurus.config.ts)
- removes logging of OfflineApi
- 