### PR TITLE
prevent adding page_id to partials

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -36,6 +36,7 @@ import {
   socketIoNoDepWarningsPluginConfig,
 } from './src/siteConfig/pluginConfigs';
 import { useTdevContentPath } from './src/siteConfig/helpers';
+import path from 'path';
 
 const siteConfig = getSiteConfig();
 
@@ -221,6 +222,14 @@ const config: Config = applyTransformers({
     parseFrontMatter: async (params) => {
       const result = await params.defaultParseFrontMatter(params);
       if (process.env.NODE_ENV === 'production') {
+        return result;
+      }
+      /**
+       * don't add frontmatter to partials
+       */
+      const fileName = path.basename(params.filePath);
+      if (fileName.startsWith('_')) {
+        // it is a partial, don't add frontmatter
         return result;
       }
       /**


### PR DESCRIPTION
Docusaurus can display partials https://docusaurus.io/docs/markdown-features/react#importing-markdown

But partials should not have a frontmatter.

This fix prevents the automatic addition of the page_id to partial pages (startibg with a `_`)