### PR TITLE
add options to extend pages configforma

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -210,7 +210,8 @@ const config: Config = applyTransformers({
           remarkPlugins: REMARK_PLUGINS,
           rehypePlugins: REHYPE_PLUGINS,
           beforeDefaultRemarkPlugins: BEFORE_DEFAULT_REMARK_PLUGINS,
-          editUrl: `/cms/${ORGANIZATION_NAME}/${PROJECT_NAME}/`
+          editUrl: `/cms/${ORGANIZATION_NAME}/${PROJECT_NAME}/`,
+          ...(siteConfig.pages || {})
         },
         theme: {
           customCss: siteConfig.siteStyles ? ['./src/css/custom.scss', ...siteConfig.siteStyles] : './src/css/custom.scss',
@@ -289,7 +290,8 @@ const config: Config = applyTransformers({
         remarkPlugins: REMARK_PLUGINS,
         rehypePlugins: REHYPE_PLUGINS,
         beforeDefaultRemarkPlugins: BEFORE_DEFAULT_REMARK_PLUGINS,
-        editUrl: `/cms/${ORGANIZATION_NAME}/${PROJECT_NAME}/`
+        editUrl: `/cms/${ORGANIZATION_NAME}/${PROJECT_NAME}/`,
+          ...(siteConfig.pages || {})
       },
     ]
   ],

--- a/src/siteConfig/siteConfig.d.ts
+++ b/src/siteConfig/siteConfig.d.ts
@@ -3,6 +3,7 @@ import { PluginOptions } from '@docusaurus/types';
 import { ConfigTransformer } from './transformers';
 import type { Options as DocsPluginOptions } from '@docusaurus/plugin-content-docs';
 import type { Options as BlogPluginOptions } from '@docusaurus/plugin-content-blog';
+import type { Options as PagesPluginOptions } from '@docusaurus/plugin-content-pages';
 
 export interface SiteConfig {
     /** The title of the site. */
@@ -53,7 +54,7 @@ export interface SiteConfig {
      * }
      * ```
      */
-    blog?: BlogPluginOptions | false;
+    blog?: Omit<BlogPluginOptions, 'id'> | false;
 
     /** The config of the docs plugin. It will be merged with the default options in docusaurus.config.ts
      * @example ignore the tdev blog posts
@@ -63,7 +64,21 @@ export interface SiteConfig {
      * }
      * ```
      */
-    docs?: DocsPluginOptions | false;
+    docs?: Omit<DocsPluginOptions, 'id'> | false;
+
+    /**
+     * extend th default options of the pages plugin
+     * @example add admonition types
+     * ```ts
+     * pages: {
+     *     admonitionTypes: {
+     *         keywords: ['aufgabe'],
+     *         extendDefaults: true
+     *      }
+     * }
+     * ```
+     */
+    pages?: Omit<PagesPluginOptions, 'id' | 'path'>;
 
     /** Footer configuration */
     footer?: {


### PR DESCRIPTION
Easily extend the pages config, e.g. with custom admonition types:


```ts
pages: {
    admonitionTypes: {
        keywords: ['aufgabe'],
        extendDefaults: true
     }
}
```