### PR TITLE
use default configs for the recommended markdown plugins

### DIFF
--- a/src/siteConfig/markdownPluginConfigs.ts
+++ b/src/siteConfig/markdownPluginConfigs.ts
@@ -118,11 +118,11 @@ export const recommendedRemarkPlugins = [
     mediaPluginConfig,
     kbdPluginConfig,
     remarkMathPluginConfig,
-    enumerateAnswersPlugin,
+    enumerateAnswersPluginConfig,
     pdfPluginConfig,
     pagePluginConfig,
     commentPluginConfig,
-    linkAnnotationPlugin
+    linkAnnotationPluginConfig
 ];
 
 export const recommendedRehypePlugins = [rehypeKatexPluginConfig];


### PR DESCRIPTION
two plugin configs were not used by the recommendations