### PR TITLE
Change tagline.

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,7 +44,7 @@ const TEST_USERNAMES = (process.env.TEST_USERNAMES?.split(';') || []).map((u) =>
 
 const config: Config = applyTransformers({
   title: TITLE,
-  tagline: siteConfig.tagline ?? 'Informatikunterricht heute',
+  tagline: siteConfig.tagline ?? 'Eine Plattform zur Gestaltung interaktiver Lernerlebnisse',
   favicon: siteConfig.favicon ?? 'img/favicon.ico',
 
   // Set the production url of your site here

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -44,7 +44,7 @@ const TEST_USERNAMES = (process.env.TEST_USERNAMES?.split(';') || []).map((u) =>
 
 const config: Config = applyTransformers({
   title: TITLE,
-  tagline: siteConfig.tagline ?? 'Dogfooding Teaching Features',
+  tagline: siteConfig.tagline ?? 'Informatikunterricht heute',
   favicon: siteConfig.favicon ?? 'img/favicon.ico',
 
   // Set the production url of your site here


### PR DESCRIPTION
The tagline "Dogfooding Teaching Features" no longer reflects what teaching-dev is about. My suggestion is something simple like "Informatikunterricht heute", but I'm open for different suggestions.