### PR TITLE
Show online status in account switcher

### DIFF
--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -17,12 +17,55 @@ import Popup from 'reactjs-popup';
 import _ from 'lodash';
 import { useLocation } from '@docusaurus/router';
 import Icon from '@mdi/react';
+import User from '@tdev-models/User';
+
+interface SwitchToUserButtonProps {
+    user: User;
+    isInCurrentClass?: boolean;
+}
+
+const SwitchToUserButton = observer(({user, isInCurrentClass}: SwitchToUserButtonProps) => {
+
+    const userStore = useStore('userStore');
+    const socketStore = useStore('socketStore');
+
+    return (
+        <div className={clsx(styles.switchToUserButton)}>
+            <Icon
+                path={mdiCircle}
+                size={0.3}
+                color={
+                    (
+                        userStore.isUserSwitched && userStore.viewedUser?.id == user.id
+                            ? (socketStore.connectedClients.get(user.id) || 0) >= 2
+                            : (socketStore.connectedClients.get(user.id) || 0) >= 1
+                    )
+                        ? 'var(--ifm-color-success)'
+                        : 'var(--ifm-color-danger)'
+                }
+                className={clsx(styles.liveIndicator)}
+            />
+            <Button
+                key={user.id}
+                icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
+                size={0.8}
+                className={clsx(styles.userButton)}
+                iconSide="left"
+                active={userStore.viewedUserId === user.id}
+                color={isInCurrentClass ? 'primary' : 'secondary'}
+                title={`Inhalte anzeigen für ${user.firstName} ${user.lastName}`}
+                onClick={() => userStore.switchUser(user.id)}
+            >
+                {user.nameShort}
+            </Button>
+        </div>
+    );
+});
 
 const AccountSwitcher = observer(() => {
     const isBrowser = useIsBrowser();
     const userStore = useStore('userStore');
     const location = useLocation();
-    const socketStore = useStore('socketStore');
 
     if (!isBrowser || !userStore.current?.hasElevatedAccess) {
         return null;
@@ -72,36 +115,11 @@ const AccountSwitcher = observer(() => {
                                 ),
                                 ['firstName']
                             ).map((user) => (
-                                <div className={clsx(styles.switchToUserButton)}>
-                                    <Icon
-                                        path={mdiCircle}
-                                        size={0.3}
-                                        color={
-                                            (
-                                                userStore.isUserSwitched &&
-                                                userStore.viewedUser?.id == user.id
-                                                    ? (socketStore.connectedClients.get(user.id) || 0) >= 2
-                                                    : (socketStore.connectedClients.get(user.id) || 0) >= 1
-                                            )
-                                                ? 'var(--ifm-color-success)'
-                                                : 'var(--ifm-color-danger)'
-                                        }
-                                        className={clsx(styles.liveIndicator)}
-                                    />
-                                    <Button
-                                        key={user.id}
-                                        icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
-                                        size={0.8}
-                                        className={clsx(styles.userButton)}
-                                        iconSide="left"
-                                        active={userStore.viewedUserId === user.id}
-                                        color="primary"
-                                        title={`Inhalte anzeigen für ${user.firstName} ${user.lastName}`}
-                                        onClick={() => userStore.switchUser(user.id)}
-                                    >
-                                        {user.nameShort}
-                                    </Button>
-                                </div>
+                                <SwitchToUserButton
+                                    key={user.id}
+                                    user={user}
+                                    isInCurrentClass={true}
+                                />
                             ))}
                             {_.orderBy(
                                 userStore.managedUsers.filter(
@@ -109,19 +127,11 @@ const AccountSwitcher = observer(() => {
                                 ),
                                 ['firstName']
                             ).map((user) => (
-                                <Button
+                                <SwitchToUserButton
                                     key={user.id}
-                                    icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
-                                    size={0.8}
-                                    className={clsx(styles.userButton)}
-                                    iconSide="left"
-                                    active={userStore.viewedUserId === user.id}
-                                    color="secondary"
-                                    title={`Inhalte anzeigen für ${user.firstName} ${user.lastName}`}
-                                    onClick={() => userStore.switchUser(user.id)}
-                                >
-                                    {user.nameShort}
-                                </Button>
+                                    user={user}
+                                    isInCurrentClass={false}
+                                />
                             ))}
                         </div>
                     </div>

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -3,18 +3,26 @@ import clsx from 'clsx';
 
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
-import { mdiAccountCircleOutline, mdiAccountSwitch, mdiHomeAccount, mdiShieldAccount } from '@mdi/js';
+import {
+    mdiAccountCircleOutline,
+    mdiAccountSwitch,
+    mdiCircle,
+    mdiHomeAccount,
+    mdiShieldAccount
+} from '@mdi/js';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import Popup from 'reactjs-popup';
 import _ from 'lodash';
 import { useLocation } from '@docusaurus/router';
+import Icon from '@mdi/react';
 
 const AccountSwitcher = observer(() => {
     const isBrowser = useIsBrowser();
     const userStore = useStore('userStore');
     const location = useLocation();
+    const socketStore = useStore('socketStore');
 
     if (!isBrowser || !userStore.current?.hasElevatedAccess) {
         return null;
@@ -64,19 +72,31 @@ const AccountSwitcher = observer(() => {
                                 ),
                                 ['firstName']
                             ).map((user) => (
-                                <Button
-                                    key={user.id}
-                                    icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
-                                    size={0.8}
-                                    className={clsx(styles.userButton)}
-                                    iconSide="left"
-                                    active={userStore.viewedUserId === user.id}
-                                    color="primary"
-                                    title={`Inhalte anzeigen für ${user.firstName} ${user.lastName}`}
-                                    onClick={() => userStore.switchUser(user.id)}
-                                >
-                                    {user.nameShort}
-                                </Button>
+                                <div className={clsx(styles.switchToUserButton)}>
+                                    <Icon
+                                        path={mdiCircle}
+                                        size={0.3}
+                                        color={
+                                            (socketStore.connectedClients.get(user.id) || 0) >= 1
+                                                ? 'var(--ifm-color-success)'
+                                                : 'var(--ifm-color-danger)'
+                                        }
+                                        className={clsx(styles.liveIndicator)}
+                                    />
+                                    <Button
+                                        key={user.id}
+                                        icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
+                                        size={0.8}
+                                        className={clsx(styles.userButton)}
+                                        iconSide="left"
+                                        active={userStore.viewedUserId === user.id}
+                                        color="primary"
+                                        title={`Inhalte anzeigen für ${user.firstName} ${user.lastName}`}
+                                        onClick={() => userStore.switchUser(user.id)}
+                                    >
+                                        {user.nameShort}
+                                    </Button>
+                                </div>
                             ))}
                             {_.orderBy(
                                 userStore.managedUsers.filter(

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -24,8 +24,7 @@ interface SwitchToUserButtonProps {
     isInCurrentClass?: boolean;
 }
 
-const SwitchToUserButton = observer(({user, isInCurrentClass}: SwitchToUserButtonProps) => {
-
+const SwitchToUserButton = observer(({ user, isInCurrentClass }: SwitchToUserButtonProps) => {
     const userStore = useStore('userStore');
     const socketStore = useStore('socketStore');
 
@@ -115,11 +114,7 @@ const AccountSwitcher = observer(() => {
                                 ),
                                 ['firstName']
                             ).map((user) => (
-                                <SwitchToUserButton
-                                    key={user.id}
-                                    user={user}
-                                    isInCurrentClass={true}
-                                />
+                                <SwitchToUserButton key={user.id} user={user} isInCurrentClass={true} />
                             ))}
                             {_.orderBy(
                                 userStore.managedUsers.filter(
@@ -127,11 +122,7 @@ const AccountSwitcher = observer(() => {
                                 ),
                                 ['firstName']
                             ).map((user) => (
-                                <SwitchToUserButton
-                                    key={user.id}
-                                    user={user}
-                                    isInCurrentClass={false}
-                                />
+                                <SwitchToUserButton key={user.id} user={user} isInCurrentClass={false} />
                             ))}
                         </div>
                     </div>

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -45,7 +45,6 @@ const SwitchToUserButton = observer(({ user, isInCurrentClass }: SwitchToUserBut
                 className={clsx(styles.liveIndicator)}
             />
             <Button
-                key={user.id}
                 icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
                 size={0.8}
                 className={clsx(styles.userButton)}

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -77,7 +77,12 @@ const AccountSwitcher = observer(() => {
                                         path={mdiCircle}
                                         size={0.3}
                                         color={
-                                            (socketStore.connectedClients.get(user.id) || 0) >= 1
+                                            (
+                                                userStore.isUserSwitched &&
+                                                userStore.viewedUser?.id == user.id
+                                                    ? (socketStore.connectedClients.get(user.id) || 0) >= 2
+                                                    : (socketStore.connectedClients.get(user.id) || 0) >= 1
+                                            )
                                                 ? 'var(--ifm-color-success)'
                                                 : 'var(--ifm-color-danger)'
                                         }

--- a/src/components/Navbar/AccountSwitcher/styles.module.scss
+++ b/src/components/Navbar/AccountSwitcher/styles.module.scss
@@ -15,3 +15,13 @@
         }
     }
 }
+
+.switchToUserButton {
+    width: fit-content;
+    position: relative;
+    .liveIndicator {
+        position: absolute;
+        left: 3px;
+        top: 1px;
+    }
+}


### PR DESCRIPTION
As a teacher, I want to be able to see which students in my current class are online / offline (especially before using a "Request Target" navigation).

Since the account switcher dropdown is always accessible and it already separates users in the current class from other users, this PR adds a live indicator to each user button in that dropdown.

We could consider only showing that indicator for users in the current class (i.e. the ones displays with a primary button).