### PR TITLE
Task state overview: Show badges for "missing" students.

### DIFF
--- a/src/components/EditingOverview/index.tsx
+++ b/src/components/EditingOverview/index.tsx
@@ -99,6 +99,17 @@ const EditingOverview = observer(() => {
                                         </div>
                                     );
                                 })}
+                                {currentPage.userIdsWithoutEditingState.map((userId) => {
+                                    const user = userStore.find(userId);
+                                    return (
+                                        <div key={userId} className={clsx(styles.usersTasks)}>
+                                            <span className={styles.user}>{user!.nameShort}</span>
+                                            <div>
+                                                <span className="badge badge--secondary">nicht geöffnet</span>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
                             </div>
                         </div>
                     </div>

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -140,4 +140,16 @@ export default class Page {
             (doc) => doc.authorId
         );
     }
+
+    @computed
+    get userIdsWithoutEditingState(): string[] {
+        const editingStates = this.editingStateByUsers;
+        const userIds: string[] = [];
+        this.activeStudentGroup?.userIds.forEach((userId) => {
+            if (!editingStates[userId]) {
+                userIds.push(userId);
+            }
+        });
+        return userIds;
+    }
 }

--- a/src/models/Page.ts
+++ b/src/models/Page.ts
@@ -144,12 +144,6 @@ export default class Page {
     @computed
     get userIdsWithoutEditingState(): string[] {
         const editingStates = this.editingStateByUsers;
-        const userIds: string[] = [];
-        this.activeStudentGroup?.userIds.forEach((userId) => {
-            if (!editingStates[userId]) {
-                userIds.push(userId);
-            }
-        });
-        return userIds;
+        return Array.from(this.activeStudentGroup?.userIds ?? []).filter((userId) => !editingStates[userId]);
     }
 }


### PR DESCRIPTION
The task state overview only lists students who have at least opened the current page. As a teacher, I also want to know which students haven't yet progressed to this page. This PR displays these "missing" students in the task state overview using a badge "nicht geöffnet".

Closes #222.