### PR TITLE
Add more live status indicators

### DIFF
--- a/src/components/Admin/UserTable/User.tsx
+++ b/src/components/Admin/UserTable/User.tsx
@@ -6,10 +6,9 @@ import { observer } from 'mobx-react-lite';
 import { default as UserModel } from '@tdev-models/User';
 import CopyBadge from '@tdev-components/shared/CopyBadge';
 import { formatDateTime } from '@tdev-models/helpers/date';
-import Icon from '@mdi/react';
-import { mdiCircle } from '@mdi/js';
 import { Role, RoleAccessLevel, RoleNames } from '@tdev-api/user';
 import { useStore } from '@tdev-hooks/useStore';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 
 interface Props {
     user: UserModel;
@@ -26,11 +25,7 @@ const UserTableRow = observer((props: Props) => {
         <tr className={clsx(styles.user)}>
             <td>
                 <div className={clsx(styles.clients)}>
-                    <Icon
-                        path={mdiCircle}
-                        size={0.6}
-                        color={user.connectedClients ? 'var(--ifm-color-success)' : 'var(--ifm-color-danger)'}
-                    />
+                    <LiveStatusIndicator size={0.6} userId={user.id} />
                     {user.connectedClients > 0 && (
                         <span className={clsx('badge badge--primary')}>{user.connectedClients}</span>
                     )}

--- a/src/components/EditingOverview/index.tsx
+++ b/src/components/EditingOverview/index.tsx
@@ -14,6 +14,7 @@ import { RWAccess } from '@tdev-models/helpers/accessPolicy';
 import _ from 'es-toolkit/compat';
 import PageStudentGroupFilter from '@tdev-components/shared/PageStudentGroupFilter';
 import useIsBrowser from '@docusaurus/useIsBrowser';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 
 export const mdiColor: { [key in StateType]: string } = {
     checked: '--ifm-color-success',
@@ -90,7 +91,16 @@ const EditingOverview = observer(() => {
                                 ).map((docs, idx) => {
                                     return (
                                         <div key={idx} className={clsx(styles.usersTasks)}>
-                                            <span className={styles.user}>{docs[0].author?.nameShort}</span>
+                                            <div>
+                                                <LiveStatusIndicator
+                                                    size={0.3}
+                                                    userId={docs[0].author?.id}
+                                                    className={clsx(styles.liveStatusIndicator)}
+                                                />
+                                                <span className={styles.user}>
+                                                    {docs[0].author?.nameShort}
+                                                </span>
+                                            </div>
                                             <div>
                                                 <div className={styles.tasks}>
                                                     <EditingStateList editingStatus={docs} />
@@ -103,7 +113,14 @@ const EditingOverview = observer(() => {
                                     const user = userStore.find(userId);
                                     return (
                                         <div key={userId} className={clsx(styles.usersTasks)}>
-                                            <span className={styles.user}>{user!.nameShort}</span>
+                                            <div>
+                                                <LiveStatusIndicator
+                                                    size={0.3}
+                                                    userId={user!.id}
+                                                    className={clsx(styles.liveStatusIndicator)}
+                                                />
+                                                <span className={styles.user}>{user!.nameShort}</span>
+                                            </div>
                                             <div>
                                                 <span className="badge badge--secondary">nicht geöffnet</span>
                                             </div>

--- a/src/components/EditingOverview/styles.module.scss
+++ b/src/components/EditingOverview/styles.module.scss
@@ -24,6 +24,7 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    white-space: nowrap;
     .tasks {
         margin-right: 0;
     }

--- a/src/components/EditingOverview/styles.module.scss
+++ b/src/components/EditingOverview/styles.module.scss
@@ -47,6 +47,10 @@
             background-color: var(--ifm-color-primary-contrast-background);
         }
     }
+
+    .liveStatusIndicator {
+        margin-right: 0.5em;
+    }
 }
 
 .button {

--- a/src/components/LiveStatusIndicator/index.tsx
+++ b/src/components/LiveStatusIndicator/index.tsx
@@ -2,8 +2,8 @@ import Icon from '@mdi/react';
 import { mdiCircle } from '@mdi/js';
 import { useStore } from '@tdev-hooks/useStore';
 import clsx from 'clsx';
-import styles from './styles.module.scss';
 import { useIsLive } from '@tdev-hooks/useIsLive';
+import { observer } from 'mobx-react-lite';
 
 interface Props {
     userId?: string;
@@ -11,30 +11,24 @@ interface Props {
     className?: string;
 }
 
-const countConnectedClients = (userId: string) => {
+const LiveStatusIndicator = observer(({ userId, size, className }: Props) => {
+    const isLive = useIsLive();
     const userStore = useStore('userStore');
     const socketStore = useStore('socketStore');
-
-    const connectedClients = socketStore.connectedClients.get(userId) || 0;
-    const viewingThisUser = userStore.isUserSwitched && userId === userStore.viewedUser?.id;
-    return Math.max(viewingThisUser ? connectedClients - 1 : connectedClients, 0);
-};
-
-const LiveStatusIndicator = ({ userId, size, className }: Props) => {
-    const isLive = useIsLive();
-
+    const connectedClients = socketStore.connectedClients.get(userId ?? '') || 0;
+    const openConnections = Math.max(userStore.isUserSwitched ? connectedClients - 1 : connectedClients, 0);
     return (
         <Icon
             path={mdiCircle}
             size={size ?? 0.3}
             color={
-                (!!userId ? countConnectedClients(userId) > 0 : isLive)
+                (!!userId ? openConnections > 0 : isLive)
                     ? 'var(--ifm-color-success)'
                     : 'var(--ifm-color-danger)'
             }
-            className={className ?? ''}
+            className={clsx(className)}
         />
     );
-};
+});
 
 export default LiveStatusIndicator;

--- a/src/components/LiveStatusIndicator/index.tsx
+++ b/src/components/LiveStatusIndicator/index.tsx
@@ -17,7 +17,6 @@ const countConnectedClients = (userId: string) => {
 
     const connectedClients = socketStore.connectedClients.get(userId) || 0;
     const viewingThisUser = userStore.isUserSwitched && userId === userStore.viewedUser?.id;
-    console.log({ connectedClients, viewingThisUser });
     return Math.max(viewingThisUser ? connectedClients - 1 : connectedClients, 0);
 };
 

--- a/src/components/LiveStatusIndicator/index.tsx
+++ b/src/components/LiveStatusIndicator/index.tsx
@@ -1,0 +1,40 @@
+import Icon from '@mdi/react';
+import { mdiCircle } from '@mdi/js';
+import { useStore } from '@tdev-hooks/useStore';
+import clsx from 'clsx';
+import styles from './styles.module.scss';
+import { useIsLive } from '@tdev-hooks/useIsLive';
+
+interface Props {
+    userId?: string;
+    size?: number;
+    className?: string;
+}
+
+const countConnectedClients = (userId: string) => {
+    const userStore = useStore('userStore');
+    const socketStore = useStore('socketStore');
+
+    const connectedClients = socketStore.connectedClients.get(userId) || 0;
+    const viewingThisUser = userId === userStore.viewedUser?.id;
+    return Math.max(viewingThisUser ? connectedClients - 1 : connectedClients, 0);
+};
+
+const LiveStatusIndicator = ({ userId, size, className }: Props) => {
+    const isLive = useIsLive();
+
+    return (
+        <Icon
+            path={mdiCircle}
+            size={size ?? 0.3}
+            color={
+                (!!userId ? countConnectedClients(userId) : isLive)
+                    ? 'var(--ifm-color-success)'
+                    : 'var(--ifm-color-danger)'
+            }
+            className={className ?? ''}
+        />
+    );
+};
+
+export default LiveStatusIndicator;

--- a/src/components/LiveStatusIndicator/index.tsx
+++ b/src/components/LiveStatusIndicator/index.tsx
@@ -16,7 +16,8 @@ const countConnectedClients = (userId: string) => {
     const socketStore = useStore('socketStore');
 
     const connectedClients = socketStore.connectedClients.get(userId) || 0;
-    const viewingThisUser = userId === userStore.viewedUser?.id;
+    const viewingThisUser = userStore.isUserSwitched && userId === userStore.viewedUser?.id;
+    console.log({ connectedClients, viewingThisUser });
     return Math.max(viewingThisUser ? connectedClients - 1 : connectedClients, 0);
 };
 
@@ -28,7 +29,7 @@ const LiveStatusIndicator = ({ userId, size, className }: Props) => {
             path={mdiCircle}
             size={size ?? 0.3}
             color={
-                (!!userId ? countConnectedClients(userId) : isLive)
+                (!!userId ? countConnectedClients(userId) > 0 : isLive)
                     ? 'var(--ifm-color-success)'
                     : 'var(--ifm-color-danger)'
             }

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -18,6 +18,7 @@ import _ from 'es-toolkit/compat';
 import { useLocation } from '@docusaurus/router';
 import Icon from '@mdi/react';
 import User from '@tdev-models/User';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 
 interface SwitchToUserButtonProps {
     user: User;
@@ -26,24 +27,10 @@ interface SwitchToUserButtonProps {
 
 const SwitchToUserButton = observer(({ user, isInCurrentClass }: SwitchToUserButtonProps) => {
     const userStore = useStore('userStore');
-    const socketStore = useStore('socketStore');
 
     return (
         <div className={clsx(styles.switchToUserButton)}>
-            <Icon
-                path={mdiCircle}
-                size={0.3}
-                color={
-                    (
-                        userStore.isUserSwitched && userStore.viewedUser?.id == user.id
-                            ? (socketStore.connectedClients.get(user.id) || 0) >= 2
-                            : (socketStore.connectedClients.get(user.id) || 0) >= 1
-                    )
-                        ? 'var(--ifm-color-success)'
-                        : 'var(--ifm-color-danger)'
-                }
-                className={clsx(styles.liveIndicator)}
-            />
+            <LiveStatusIndicator userId={user.id} size={0.3} className={clsx(styles.liveIndicator)} />
             <Button
                 icon={user.isStudent ? mdiAccountCircleOutline : mdiShieldAccount}
                 className={clsx(styles.userButton)}

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -11,6 +11,7 @@ import Icon from '@mdi/react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import { useIsLive } from '@tdev-hooks/useIsLive';
 import useIsMobileView from '@tdev-hooks/useIsMobileView';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 const { NO_AUTH } = siteConfig.customFields as { NO_AUTH?: boolean };
 
 const LoginButton = () => {
@@ -46,23 +47,7 @@ const LoginProfileButton = observer(() => {
                         className={clsx(styles.button)}
                         textClassName={clsx(styles.text)}
                     />
-                    <Icon
-                        path={mdiCircle}
-                        size={0.3}
-                        color={
-                            (
-                                userStore.isUserSwitched
-                                    ? (socketStore.connectedClients.get(userStore.viewedUser?.id || ' ') ||
-                                          1) -
-                                          1 >
-                                      0
-                                    : isLive
-                            )
-                                ? 'var(--ifm-color-success)'
-                                : 'var(--ifm-color-danger)'
-                        }
-                        className={clsx(styles.liveIndicator)}
-                    />
+                    <LiveStatusIndicator size={0.3} className={clsx(styles.liveIndicator)} />
                 </>
             ) : (
                 <Button

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -3,13 +3,11 @@ import clsx from 'clsx';
 
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
-import { mdiAccountCircleOutline, mdiCircle, mdiLogin } from '@mdi/js';
+import { mdiAccountCircleOutline, mdiLogin } from '@mdi/js';
 import siteConfig from '@generated/docusaurus.config';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
-import Icon from '@mdi/react';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import { useIsLive } from '@tdev-hooks/useIsLive';
 import useIsMobileView from '@tdev-hooks/useIsMobileView';
 import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 const { NO_AUTH } = siteConfig.customFields as { NO_AUTH?: boolean };
@@ -23,8 +21,6 @@ const LoginProfileButton = observer(() => {
     const isMobile = useIsMobileView(502);
     const userStore = useStore('userStore');
     const sessionStore = useStore('sessionStore');
-    const socketStore = useStore('socketStore');
-    const isLive = useIsLive();
 
     if (!isBrowser) {
         return null;

--- a/src/components/StudentGroup/AddMembersPopup/AddUser.tsx
+++ b/src/components/StudentGroup/AddMembersPopup/AddUser.tsx
@@ -6,6 +6,7 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import { _AddMembersPopupPropsInternal } from './types';
 import Button from '@tdev-components/shared/Button';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 
 const AddUser = observer((props: _AddMembersPopupPropsInternal) => {
     const userStore = useStore('userStore');
@@ -33,33 +34,38 @@ const AddUser = observer((props: _AddMembersPopupPropsInternal) => {
                         setSearchFilter(e.target.value);
                     }}
                 />
-                <div className={styles.listContainer}>
-                    <ul className={clsx(styles.students, styles.list)}>
+                <div>
+                    <div className={clsx(styles.list)}>
                         {userStore.users
                             .filter((user) => searchRegex.test(user.searchTerm))
                             .map((user, idx) => (
-                                <li
+                                <div
                                     key={idx}
                                     className={clsx(
-                                        styles.listItem,
-                                        group.userIds.has(user.id) && styles.disabled
+                                        group.userIds.has(user.id) && styles.disabled,
+                                        styles.addUserListItem
                                     )}
                                     title={user.email}
                                 >
-                                    {user.nameShort}
-                                    <div className={styles.actions}>
-                                        <Button
-                                            onClick={() => {
-                                                group.addStudent(user);
-                                            }}
-                                            disabled={group.userIds.has(user.id)}
-                                            icon={mdiAccountPlus}
-                                            color="green"
-                                        />
+                                    <div className={styles.listItem}>
+                                        <span>
+                                            <LiveStatusIndicator userId={user.id} size={0.3} />{' '}
+                                            {user.nameShort}
+                                        </span>
+                                        <div className={styles.actions}>
+                                            <Button
+                                                onClick={() => {
+                                                    group.addStudent(user);
+                                                }}
+                                                disabled={group.userIds.has(user.id)}
+                                                icon={mdiAccountPlus}
+                                                color="green"
+                                            />
+                                        </div>
                                     </div>
-                                </li>
+                                </div>
                             ))}
-                    </ul>
+                    </div>
                 </div>
             </div>
         </>

--- a/src/components/StudentGroup/AddMembersPopup/ImportGroup.tsx
+++ b/src/components/StudentGroup/AddMembersPopup/ImportGroup.tsx
@@ -32,12 +32,12 @@ const ImportGroup = observer((props: _AddMembersPopupPropsInternal) => {
                     }}
                 />
                 <div className={styles.listContainer}>
-                    <ul className={clsx(styles.students, styles.list)}>
+                    <div className={clsx(styles.list)}>
                         {studentGroupStore.managedStudentGroups
                             .filter((group) => group.id !== props.studentGroup.id)
                             .filter((user) => searchRegex.test(user.searchTerm))
                             .map((group, idx) => (
-                                <li
+                                <div
                                     key={idx}
                                     className={clsx(
                                         styles.listItem,
@@ -66,9 +66,9 @@ const ImportGroup = observer((props: _AddMembersPopupPropsInternal) => {
                                             color="green"
                                         />
                                     </div>
-                                </li>
+                                </div>
                             ))}
-                    </ul>
+                    </div>
                 </div>
             </div>
         </>

--- a/src/components/StudentGroup/AddMembersPopup/styles.module.scss
+++ b/src/components/StudentGroup/AddMembersPopup/styles.module.scss
@@ -8,6 +8,29 @@
     --ifm-tabs-padding-horizontal: 0.6em;
 }
 
+.list {
+    > :nth-child(2n) {
+        background-color: var(--ifm-color-secondary-lightest);
+    }
+
+    > :hover {
+        background-color: var(--ifm-color-primary-contrast-background);
+    }
+
+    .listItem {
+        display: flex;
+        justify-content: space-between;
+    }
+}
+
+[data-theme='dark'] {
+    .list {
+        > :nth-child(2n) {
+            background-color: var(--ifm-color-secondary-contrast-background);
+        }
+    }
+}
+
 .addUserCardTitle {
     display: flex;
     flex-direction: row;

--- a/src/components/StudentGroup/index.tsx
+++ b/src/components/StudentGroup/index.tsx
@@ -24,6 +24,7 @@ import { SIZE_S } from '@tdev-components/shared/iconSizes';
 import { Confirm } from '@tdev-components/shared/Button/Confirm';
 import Undo from './Undo';
 import AddUserPopup from './AddMembersPopup';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 
 interface Props {
     studentGroup: StudentGroupModel;
@@ -268,6 +269,11 @@ const StudentGroup = observer((props: Props) => {
                             <ul className={clsx(styles.students, styles.list)}>
                                 {group.students.map((student, idx) => (
                                     <li key={idx} className={clsx(styles.listItem)}>
+                                        <LiveStatusIndicator
+                                            userId={student.id}
+                                            size={0.3}
+                                            className={clsx(styles.liveStatusIndicator)}
+                                        />
                                         {student.nameShort}
                                         {isAdmin && (
                                             <div className={styles.actions}>

--- a/src/components/StudentGroup/styles.module.scss
+++ b/src/components/StudentGroup/styles.module.scss
@@ -31,6 +31,7 @@
             flex-direction: row;
             padding-left: 0;
             .listItem {
+                position: relative;
                 flex-basis: 10em;
                 flex-grow: 1;
                 display: flex;
@@ -100,4 +101,10 @@
     display: flex;
     flex-direction: row;
     gap: 0.5em;
+}
+
+.liveStatusIndicator {
+    position: absolute;
+    left: 7px;
+    top: 7px;
 }


### PR DESCRIPTION
- Factor duplicated live status indicator out into its own component
- To get a better overview of who is currently online during class, add the live status indicator to:
  - task state overview
  - admin group management panels
- As a result: Rework styling for adding members / gropus to groups

<img width="334" height="703" alt="Bildschirmfoto 2025-09-01 um 11 42 58" src="https://github.com/user-attachments/assets/bca1ecfe-6dde-4a3e-8d5d-877f1d13caaa" />

<img width="637" height="747" alt="Bildschirmfoto 2025-09-01 um 11 42 33" src="https://github.com/user-attachments/assets/bda5b686-b8e7-44d1-92f2-8f800b2cf203" />

<img width="1467" height="836" alt="Bildschirmfoto 2025-09-01 um 11 43 30" src="https://github.com/user-attachments/assets/c68361a7-bffd-409c-a2d5-19adf2716386" />