### PR TITLE
[WIP] Admin quality of life improvements

### DIFF
--- a/src/components/Admin/StudentGroupPanel/index.tsx
+++ b/src/components/Admin/StudentGroupPanel/index.tsx
@@ -4,36 +4,70 @@ import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
-import { mdiPlusCircleOutline } from '@mdi/js';
+import { mdiMagnify, mdiPlusCircleOutline, mdiRestore } from '@mdi/js';
 import StudentGroup from '@tdev-components/StudentGroup';
 import _ from 'es-toolkit/compat';
-import scheduleMicrotask from '@tdev-components/util/scheduleMicrotask';
 import { action } from 'mobx';
+import Icon from '@mdi/react';
 
 const StudentGroupPanel = observer(() => {
     const userStore = useStore('userStore');
     const groupStore = useStore('studentGroupStore');
     const current = userStore.current;
+    const [searchFilter, setSearchFilter] = React.useState('');
+    const [searchRegex, setSearchRegex] = React.useState(new RegExp(searchFilter, 'i'));
+
+    React.useEffect(() => {
+        setSearchRegex(new RegExp(searchFilter, 'i'));
+    }, [searchFilter]);
+
     if (!current?.hasElevatedAccess) {
         return null;
     }
     return (
         <div>
-            <Button
-                onClick={() => {
-                    groupStore.create('', '').then(
-                        action((group) => {
-                            group?.setEditing(true);
-                        })
-                    );
-                }}
-                icon={mdiPlusCircleOutline}
-                color="primary"
-                text="Neue Lerngruppe erstellen"
-            />
+            <div className={clsx(styles.controls)}>
+                <Button
+                    onClick={() => {
+                        groupStore.create('', '').then(
+                            action((group) => {
+                                group?.setEditing(true);
+                            })
+                        );
+                    }}
+                    icon={mdiPlusCircleOutline}
+                    color="primary"
+                    text="Neue Lerngruppe erstellen"
+                />
+                <div className={clsx(styles.searchBox)}>
+                    <Icon path={mdiMagnify} size={1} />
+                    <div className={clsx(styles.searchInput)}>
+                        <input
+                            type="text"
+                            placeholder="Lerngruppen filtern..."
+                            value={searchFilter}
+                            className={clsx(styles.textInput)}
+                            onChange={(e) => {
+                                setSearchFilter(e.target.value);
+                            }}
+                        />
+                        <Button
+                            onClick={() => {
+                                setSearchFilter('');
+                            }}
+                            icon={mdiRestore}
+                            size={0.8}
+                            noBorder
+                            color="secondary"
+                        />
+                    </div>
+                </div>
+            </div>
             <div className={clsx(styles.studentGroups)}>
                 {_.orderBy(
-                    groupStore.managedStudentGroups.filter((g) => !g.parentId),
+                    groupStore.managedStudentGroups
+                        .filter((g) => !g.parentId)
+                        .filter((user) => searchRegex.test(user.searchTerm)),
                     ['_pristine.name', 'createdAt'],
                     ['asc', 'desc']
                 ).map((group) => (

--- a/src/components/Admin/StudentGroupPanel/styles.module.scss
+++ b/src/components/Admin/StudentGroupPanel/styles.module.scss
@@ -1,3 +1,43 @@
+.controls {
+    display: flex;
+    flex-direction: row;
+    gap: 1em;
+    width: 100%;
+    margin-bottom: 0.5em;
+    flex-wrap: wrap;
+
+    .searchBox {
+        display: flex;
+        align-items: center;
+        grid-area: 0.5em;
+        flex-grow: 1;
+        border: 1px solid var(--ifm-color-secondary);
+        border-radius: var(--ifm-global-radius);
+        padding: 0 0.2em;
+
+        .searchInput {
+            display: flex;
+            align-items: stretch;
+            width: 100%;
+
+            input[type='text'] {
+                flex-grow: 1;
+                border: none;
+                outline: none;
+                padding: 0.5em;
+                border-radius: 4px;
+                background-color: transparent;
+                width: 100%;
+
+                &::placeholder {
+                    color: inherit;
+                    opacity: 0.5;
+                }
+            }
+        }
+    }
+}
+
 .studentGroups {
     display: flex;
     flex-direction: row;

--- a/src/components/Navbar/LoginProfileButton/AdminNavPopup.tsx
+++ b/src/components/Navbar/LoginProfileButton/AdminNavPopup.tsx
@@ -1,0 +1,61 @@
+import { mdiAccountDetailsOutline, mdiAccountSupervisorOutline, mdiShieldAccountOutline } from '@mdi/js';
+import clsx from 'clsx';
+import Popup from 'reactjs-popup';
+import styles from './styles.module.scss';
+import ProfileButton from './ProfileButton';
+import Button from '@tdev-components/shared/Button';
+
+interface AdminNavButtonProps {
+    href: string;
+    text: string;
+    icon: string;
+}
+
+const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
+    return (
+        <Button
+            href={href}
+            text={text}
+            icon={icon}
+            iconSide="left"
+            color="primary"
+            className={clsx(styles.adminNavButton)}
+            textClassName={clsx(styles.adminNavButtonText)}
+        />
+    );
+};
+
+const AdminNavPopup = () => {
+    return (
+        <Popup
+            trigger={
+                <div>
+                    <ProfileButton />
+                </div>
+            }
+            on={['hover']}
+            closeOnDocumentClick
+            closeOnEscape
+        >
+            <div className={clsx(styles.adminNavPopup)}>
+                <AdminNavButton
+                    href="/admin?panel=studentGroups"
+                    text="Lerngruppen"
+                    icon={mdiAccountSupervisorOutline}
+                />
+                <AdminNavButton
+                    href="/admin?panel=accounts"
+                    text="Accounts"
+                    icon={mdiAccountDetailsOutline}
+                />
+                <AdminNavButton
+                    href="/admin?panel=allowedActions"
+                    text="Erlaubte Aktionen"
+                    icon={mdiShieldAccountOutline}
+                />
+            </div>
+        </Popup>
+    );
+};
+
+export default AdminNavPopup;

--- a/src/components/Navbar/LoginProfileButton/AdminNavPopup.tsx
+++ b/src/components/Navbar/LoginProfileButton/AdminNavPopup.tsx
@@ -1,9 +1,16 @@
-import { mdiAccountDetailsOutline, mdiAccountSupervisorOutline, mdiShieldAccountOutline } from '@mdi/js';
+import {
+    mdiAccountCircleOutline,
+    mdiAccountDetailsOutline,
+    mdiAccountSupervisorOutline,
+    mdiShieldAccountOutline
+} from '@mdi/js';
 import clsx from 'clsx';
 import Popup from 'reactjs-popup';
 import styles from './styles.module.scss';
 import ProfileButton from './ProfileButton';
 import Button from '@tdev-components/shared/Button';
+import { useLocation } from '@docusaurus/router';
+import { useStore } from '@tdev-hooks/useStore';
 
 interface AdminNavButtonProps {
     href: string;
@@ -12,6 +19,8 @@ interface AdminNavButtonProps {
 }
 
 const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
+    const location = useLocation();
+
     return (
         <Button
             href={href}
@@ -19,6 +28,7 @@ const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
             icon={icon}
             iconSide="left"
             color="primary"
+            active={location.pathname + location.search === href}
             className={clsx(styles.adminNavButton)}
             textClassName={clsx(styles.adminNavButtonText)}
         />
@@ -26,6 +36,8 @@ const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
 };
 
 const AdminNavPopup = () => {
+    const userStore = useStore('userStore');
+
     return (
         <Popup
             trigger={
@@ -38,6 +50,7 @@ const AdminNavPopup = () => {
             closeOnEscape
         >
             <div className={clsx(styles.adminNavPopup)}>
+                <AdminNavButton href="/user" text="Benutzer" icon={mdiAccountCircleOutline} />
                 <AdminNavButton
                     href="/admin?panel=studentGroups"
                     text="Lerngruppen"

--- a/src/components/Navbar/LoginProfileButton/ProfileButton.tsx
+++ b/src/components/Navbar/LoginProfileButton/ProfileButton.tsx
@@ -1,0 +1,46 @@
+import { mdiAccountCircleOutline } from '@mdi/js';
+import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
+import Button from '@tdev-components/shared/Button';
+import useIsMobileView from '@tdev-hooks/useIsMobileView';
+import { useStore } from '@tdev-hooks/useStore';
+import clsx from 'clsx';
+import styles from './styles.module.scss';
+
+const ProfileButton = () => {
+    const isMobile = useIsMobileView(502);
+    const userStore = useStore('userStore');
+    const sessionStore = useStore('sessionStore');
+
+    return (
+        <div className={clsx(styles.profileButton, isMobile && styles.collapsed)}>
+            {sessionStore.apiMode === 'api' ? (
+                <>
+                    <Button
+                        text={userStore.viewedUser?.nameShort || 'Profil'}
+                        icon={mdiAccountCircleOutline}
+                        iconSide="left"
+                        color="primary"
+                        href="/user"
+                        title="Persönlicher Bereich"
+                        className={clsx(styles.button)}
+                        textClassName={clsx(styles.text)}
+                    />
+                    <LiveStatusIndicator size={0.3} className={clsx(styles.liveIndicator)} />
+                </>
+            ) : (
+                <Button
+                    icon={sessionStore.apiModeIcon}
+                    iconSide="left"
+                    color="primary"
+                    href="/user"
+                    title="Persönlicher Bereich"
+                    text="Profil"
+                    className={clsx(styles.button)}
+                    textClassName={clsx(styles.text)}
+                />
+            )}
+        </div>
+    );
+};
+
+export default ProfileButton;

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -1,83 +1,15 @@
-import React from 'react';
-import clsx from 'clsx';
-
-import styles from './styles.module.scss';
-import { observer } from 'mobx-react-lite';
-import {
-    mdiAccountCircleOutline,
-    mdiAccountDetailsOutline,
-    mdiAccountSupervisorOutline,
-    mdiLogin,
-    mdiShieldAccountOutline
-} from '@mdi/js';
-import siteConfig from '@generated/docusaurus.config';
-import { useStore } from '@tdev-hooks/useStore';
-import Button from '@tdev-components/shared/Button';
 import useIsBrowser from '@docusaurus/useIsBrowser';
-import useIsMobileView from '@tdev-hooks/useIsMobileView';
-import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
-import Popup from 'reactjs-popup';
+import siteConfig from '@generated/docusaurus.config';
+import { mdiLogin } from '@mdi/js';
+import Button from '@tdev-components/shared/Button';
+import { useStore } from '@tdev-hooks/useStore';
+import { observer } from 'mobx-react-lite';
+import AdminNavPopup from './AdminNavPopup';
+import ProfileButton from './ProfileButton';
 const { NO_AUTH } = siteConfig.customFields as { NO_AUTH?: boolean };
 
 const LoginButton = () => {
     return <Button href={'/login'} text="Login" icon={mdiLogin} color="primary" iconSide="left" />;
-};
-
-const ProfileButton = () => {
-    const isMobile = useIsMobileView(502);
-    const userStore = useStore('userStore');
-    const sessionStore = useStore('sessionStore');
-
-    return (
-        <div className={clsx(styles.profileButton, isMobile && styles.collapsed)}>
-            {sessionStore.apiMode === 'api' ? (
-                <>
-                    <Button
-                        text={userStore.viewedUser?.nameShort || 'Profil'}
-                        icon={mdiAccountCircleOutline}
-                        iconSide="left"
-                        color="primary"
-                        href="/user"
-                        title="Persönlicher Bereich"
-                        className={clsx(styles.button)}
-                        textClassName={clsx(styles.text)}
-                    />
-                    <LiveStatusIndicator size={0.3} className={clsx(styles.liveIndicator)} />
-                </>
-            ) : (
-                <Button
-                    icon={sessionStore.apiModeIcon}
-                    iconSide="left"
-                    color="primary"
-                    href="/user"
-                    title="Persönlicher Bereich"
-                    text="Profil"
-                    className={clsx(styles.button)}
-                    textClassName={clsx(styles.text)}
-                />
-            )}
-        </div>
-    );
-};
-
-interface AdminNavButtonProps {
-    href: string;
-    text: string;
-    icon: string;
-}
-
-const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
-    return (
-        <Button
-            href={href}
-            text={text}
-            icon={icon}
-            iconSide="left"
-            color="primary"
-            className={clsx(styles.adminNavButton)}
-            textClassName={clsx(styles.adminNavButtonText)}
-        />
-    );
 };
 
 const LoginProfileButton = observer(() => {
@@ -97,36 +29,7 @@ const LoginProfileButton = observer(() => {
         return <ProfileButton />;
     }
 
-    return (
-        <Popup
-            trigger={
-                <div>
-                    <ProfileButton />
-                </div>
-            }
-            on={['hover']}
-            closeOnDocumentClick
-            closeOnEscape
-        >
-            <div className={clsx(styles.adminNavPopup)}>
-                <AdminNavButton
-                    href="/admin?panel=studentGroups"
-                    text="Lerngruppen"
-                    icon={mdiAccountSupervisorOutline}
-                />
-                <AdminNavButton
-                    href="/admin?panel=accounts"
-                    text="Accounts"
-                    icon={mdiAccountDetailsOutline}
-                />
-                <AdminNavButton
-                    href="/admin?panel=allowedActions"
-                    text="Erlaubte Aktionen"
-                    icon={mdiShieldAccountOutline}
-                />
-            </div>
-        </Popup>
-    );
+    return <AdminNavPopup />;
 });
 
 export default LoginProfileButton;

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -7,7 +7,6 @@ import {
     mdiAccountCircleOutline,
     mdiAccountDetailsOutline,
     mdiAccountSupervisorOutline,
-    mdiGroup,
     mdiLogin,
     mdiShieldAccountOutline
 } from '@mdi/js';
@@ -61,6 +60,26 @@ const ProfileButton = () => {
     );
 };
 
+interface AdminNavButtonProps {
+    href: string;
+    text: string;
+    icon: string;
+}
+
+const AdminNavButton = ({ href, text, icon }: AdminNavButtonProps) => {
+    return (
+        <Button
+            href={href}
+            text={text}
+            icon={icon}
+            iconSide="left"
+            color="primary"
+            className={clsx(styles.adminNavButton)}
+            textClassName={clsx(styles.adminNavButtonText)}
+        />
+    );
+};
+
 const LoginProfileButton = observer(() => {
     const isBrowser = useIsBrowser();
     const sessionStore = useStore('sessionStore');
@@ -90,26 +109,20 @@ const LoginProfileButton = observer(() => {
             closeOnEscape
         >
             <div className={clsx(styles.adminNavPopup)}>
-                <Button
+                <AdminNavButton
                     href="/admin?panel=studentGroups"
                     text="Lerngruppen"
                     icon={mdiAccountSupervisorOutline}
-                    iconSide="left"
-                    className={clsx(styles.adminNavButton)}
                 />
-                <Button
+                <AdminNavButton
                     href="/admin?panel=accounts"
                     text="Accounts"
                     icon={mdiAccountDetailsOutline}
-                    iconSide="left"
-                    className={clsx(styles.adminNavButton)}
                 />
-                <Button
+                <AdminNavButton
                     href="/admin?panel=allowedActions"
                     text="Erlaubte Aktionen"
                     icon={mdiShieldAccountOutline}
-                    iconSide="left"
-                    className={clsx(styles.adminNavButton)}
                 />
             </div>
         </Popup>

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -3,32 +3,32 @@ import clsx from 'clsx';
 
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
-import { mdiAccountCircleOutline, mdiLogin } from '@mdi/js';
+import {
+    mdiAccountCircleOutline,
+    mdiAccountDetailsOutline,
+    mdiAccountSupervisorOutline,
+    mdiGroup,
+    mdiLogin,
+    mdiShieldAccountOutline
+} from '@mdi/js';
 import siteConfig from '@generated/docusaurus.config';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import useIsMobileView from '@tdev-hooks/useIsMobileView';
 import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
+import Popup from 'reactjs-popup';
 const { NO_AUTH } = siteConfig.customFields as { NO_AUTH?: boolean };
 
 const LoginButton = () => {
     return <Button href={'/login'} text="Login" icon={mdiLogin} color="primary" iconSide="left" />;
 };
 
-const LoginProfileButton = observer(() => {
-    const isBrowser = useIsBrowser();
+const ProfileButton = () => {
     const isMobile = useIsMobileView(502);
     const userStore = useStore('userStore');
     const sessionStore = useStore('sessionStore');
 
-    if (!isBrowser) {
-        return null;
-    }
-
-    if (!sessionStore.isLoggedIn && !NO_AUTH) {
-        return <LoginButton />;
-    }
     return (
         <div className={clsx(styles.profileButton, isMobile && styles.collapsed)}>
             {sessionStore.apiMode === 'api' ? (
@@ -58,6 +58,61 @@ const LoginProfileButton = observer(() => {
                 />
             )}
         </div>
+    );
+};
+
+const LoginProfileButton = observer(() => {
+    const isBrowser = useIsBrowser();
+    const sessionStore = useStore('sessionStore');
+    const userStore = useStore('userStore');
+
+    if (!isBrowser) {
+        return null;
+    }
+
+    if (!sessionStore.isLoggedIn && !NO_AUTH) {
+        return <LoginButton />;
+    }
+
+    if (!userStore.current?.isAdmin && !userStore.current?.isTeacher) {
+        return <ProfileButton />;
+    }
+
+    return (
+        <Popup
+            trigger={
+                <div>
+                    <ProfileButton />
+                </div>
+            }
+            on={['hover']}
+            closeOnDocumentClick
+            closeOnEscape
+        >
+            <div className={clsx(styles.adminNavPopup)}>
+                <Button
+                    href="/admin?panel=studentGroups"
+                    text="Lerngruppen"
+                    icon={mdiAccountSupervisorOutline}
+                    iconSide="left"
+                    className={clsx(styles.adminNavButton)}
+                />
+                <Button
+                    href="/admin?panel=accounts"
+                    text="Accounts"
+                    icon={mdiAccountDetailsOutline}
+                    iconSide="left"
+                    className={clsx(styles.adminNavButton)}
+                />
+                <Button
+                    href="/admin?panel=allowedActions"
+                    text="Erlaubte Aktionen"
+                    icon={mdiShieldAccountOutline}
+                    iconSide="left"
+                    className={clsx(styles.adminNavButton)}
+                />
+            </div>
+        </Popup>
     );
 });
 

--- a/src/components/Navbar/LoginProfileButton/styles.module.scss
+++ b/src/components/Navbar/LoginProfileButton/styles.module.scss
@@ -16,6 +16,17 @@
     }
 }
 
+.adminNavPopup {
+    display: flex;
+    flex-direction: column;
+    background-color: white;
+    border-radius: var(--ifm-global-radius);
+
+    .adminNavButton {
+        width: 100%;
+    }
+}
+
 :global(.navbar-sidebar) {
     .profileButton {
         display: inline-block;

--- a/src/components/Navbar/LoginProfileButton/styles.module.scss
+++ b/src/components/Navbar/LoginProfileButton/styles.module.scss
@@ -27,6 +27,13 @@
     }
 }
 
+.adminNavButtonText {
+    display: inline-flex;
+    width: 100%;
+    flex-direction: row;
+    justify-content: flex-start;
+}
+
 :global(.navbar-sidebar) {
     .profileButton {
         display: inline-block;

--- a/src/pages/user/index.tsx
+++ b/src/pages/user/index.tsx
@@ -171,22 +171,6 @@ const UserPage = observer(() => {
                             )}
                         </>
                     )}
-                </DefinitionList>
-                {userStore.current?.hasElevatedAccess && (
-                    <div>
-                        <h2>User Tabelle</h2>
-                        <div className={clsx(styles.userTable)}>
-                            <UserTable
-                                filterClassName={styles.filter}
-                                defaultSortColumn="connectedClients"
-                                defaultSortDirection="desc"
-                                showAll
-                            />
-                        </div>
-                    </div>
-                )}
-                <h2>Account</h2>
-                <DefinitionList>
                     {current?.hasElevatedAccess && (
                         <>
                             <dt>Admin</dt>


### PR DESCRIPTION
- [x] Removes the user table from the user page. It's a rather long table which is also available in the accounts admin tab. This should keep the user page a little cleaner and focused on the logged-in user's personal information.
- [x] Add a search box to the student groups admin panel
  - **Discussion question:** Do we want to also search the group description (currently, only the group name is searched)? If so, should there be a checkbox to disable that behavior?
- [ ] Add group membership buttons to students in the "add to group" popup.
- [ ] When adding a member to a subgroup, show members of the parent group first.
- [ ] Up for debate: Move the "reload page" feature away from the user page (because it doesn't really have anything to do with the user)?
- [ ] Up for debate: Shorten / hide / remove the "in Gruppen" section for admins, because it can get really long?

Closes #220.