### PR TITLE
show sync issues by tracking stalled document roots

### DIFF
--- a/src/components/LoggedOutOverlay/index.tsx
+++ b/src/components/LoggedOutOverlay/index.tsx
@@ -133,10 +133,10 @@ const LoggedOutOverlay = observer((props: Props) => {
         setSyncIssue((current) => current ?? 'offline');
     }, [socketStore.isLive, ignoredIssues, location]);
 
-    if (!delayExpired || !syncIssue || ignoredIssues.has(syncIssue)) {
+    if (!delayExpired || !syncIssue || ignoredIssues.has(syncIssue) || ignoredIssues.has('not-logged-in')) {
         return null;
     }
-    if (!userStore.current && !ignoredIssues.has('not-logged-in')) {
+    if (!userStore.current) {
         return (
             <NotLoggedInWarning
                 onDismiss={() => {

--- a/src/components/LoggedOutOverlay/index.tsx
+++ b/src/components/LoggedOutOverlay/index.tsx
@@ -11,9 +11,17 @@ interface WarningContentProps {
     onDismiss: () => void;
 }
 
+const Overlay = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <div className={styles.container}>
+            <div className={styles.content}>{children}</div>
+        </div>
+    );
+};
+
 const NotLoggedInWarning = ({ onDismiss }: WarningContentProps) => {
     return (
-        <div className={styles.content}>
+        <Overlay>
             <Admonition type="warning" title="Nicht eigenloggt">
                 <p>
                     Sie sind nicht eingeloggt. Wenn Sie ohne Login fortfahren, wird Ihr{' '}
@@ -28,13 +36,13 @@ const NotLoggedInWarning = ({ onDismiss }: WarningContentProps) => {
                     Weiter ohne Login
                 </Button>
             </div>
-        </div>
+        </Overlay>
     );
 };
 
 const DisconnectedWarning = ({ onDismiss }: WarningContentProps) => {
     return (
-        <div className={styles.content}>
+        <Overlay>
             <Admonition type="warning" title="Keine Verbindung zum Server">
                 <p>
                     Es besteht keine Verbindung zum Server – <b>Ihr Fortschritt wird nicht gespeichert</b>.
@@ -49,13 +57,13 @@ const DisconnectedWarning = ({ onDismiss }: WarningContentProps) => {
                     Offline verwenden
                 </Button>
             </div>
-        </div>
+        </Overlay>
     );
 };
 
 const StalledWarning = ({ onDismiss }: WarningContentProps) => {
     return (
-        <div className={styles.content}>
+        <Overlay>
             <Admonition type="warning" title="Keine Verbindung zum Server">
                 <p>
                     Einige Dokumente wurden nicht korrekt geladen –{' '}
@@ -71,7 +79,7 @@ const StalledWarning = ({ onDismiss }: WarningContentProps) => {
                     Ignorieren
                 </Button>
             </div>
-        </div>
+        </Overlay>
     );
 };
 

--- a/src/components/LoggedOutOverlay/index.tsx
+++ b/src/components/LoggedOutOverlay/index.tsx
@@ -130,7 +130,12 @@ const LoggedOutOverlay = observer((props: Props) => {
         if (socketStore.isLive || onLoginPage) {
             return;
         }
-        setSyncIssue((current) => current ?? 'offline');
+        // check back in 5 seconds, whether the connection is restored
+        const timeout = setTimeout(() => {
+            setSyncIssue((current) => current ?? 'offline');
+        }, 5_000);
+        // when "isLive" becomes true in the meantime, the timeout should be cleared
+        return () => clearTimeout(timeout);
     }, [socketStore.isLive, ignoredIssues, location]);
 
     if (!delayExpired || !syncIssue || ignoredIssues.has(syncIssue) || ignoredIssues.has('not-logged-in')) {

--- a/src/components/Navbar/AccountSwitcher/index.tsx
+++ b/src/components/Navbar/AccountSwitcher/index.tsx
@@ -3,20 +3,13 @@ import clsx from 'clsx';
 
 import styles from './styles.module.scss';
 import { observer } from 'mobx-react-lite';
-import {
-    mdiAccountCircleOutline,
-    mdiAccountSwitch,
-    mdiCircle,
-    mdiHomeAccount,
-    mdiShieldAccount
-} from '@mdi/js';
+import { mdiAccountCircleOutline, mdiAccountSwitch, mdiHomeAccount, mdiShieldAccount } from '@mdi/js';
 import { useStore } from '@tdev-hooks/useStore';
 import Button from '@tdev-components/shared/Button';
 import useIsBrowser from '@docusaurus/useIsBrowser';
 import Popup from 'reactjs-popup';
 import _ from 'es-toolkit/compat';
 import { useLocation } from '@docusaurus/router';
-import Icon from '@mdi/react';
 import User from '@tdev-models/User';
 import LiveStatusIndicator from '@tdev-components/LiveStatusIndicator';
 

--- a/src/components/Navbar/LoginProfileButton/index.tsx
+++ b/src/components/Navbar/LoginProfileButton/index.tsx
@@ -28,11 +28,11 @@ const LoginProfileButton = observer(() => {
         return <LoginButton />;
     }
 
-    if (!userStore.current?.isAdmin && !userStore.current?.isTeacher) {
-        return <ProfileButton />;
+    if (userStore.current?.isAdmin || userStore.current?.isTeacher) {
+        return <AdminNavPopup />;
     }
 
-    return <AdminNavPopup />;
+    return <ProfileButton />;
 });
 
 export default LoginProfileButton;

--- a/src/components/Navbar/PersonalSpaceOverlay/index.tsx
+++ b/src/components/Navbar/PersonalSpaceOverlay/index.tsx
@@ -9,11 +9,16 @@ import { PopupActions } from 'reactjs-popup/dist/types';
 import siteConfig from '@generated/docusaurus.config';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@tdev-hooks/useStore';
+import useIsBrowser from '@docusaurus/useIsBrowser';
 const { PERSONAL_SPACE_DOC_ROOT_ID } = siteConfig.customFields as { PERSONAL_SPACE_DOC_ROOT_ID: string };
 
 const PersonalSpaceOverlay = observer(() => {
+    const isBrowser = useIsBrowser();
     const sessionStore = useStore('sessionStore');
     const popupRef = React.useRef<PopupActions>(null);
+    if (!isBrowser) {
+        return null;
+    }
 
     if (sessionStore.apiMode === 'api' && !sessionStore.isLoggedIn) {
         return null;

--- a/src/components/documents/QuillV2/index.tsx
+++ b/src/components/documents/QuillV2/index.tsx
@@ -2,10 +2,8 @@ import useIsBrowser from '@docusaurus/useIsBrowser';
 import { observer } from 'mobx-react-lite';
 import * as React from 'react';
 import type { default as QuillV2Type, Props } from './QuillV2';
-import { DUMMY_DOCUMENT_ID, useFirstMainDocument } from '@tdev-hooks/useFirstMainDocument';
 import { default as QuillV2Model, ModelMeta } from '@tdev-models/documents/QuillV2';
 import { DocContext } from '@tdev-components/documents/DocumentContext';
-import { useStore } from '@tdev-hooks/useStore';
 import Loader from '@tdev-components/Loader';
 import { useFirstRealMainDocument } from '@tdev-hooks/useFirstRealMainDocument';
 

--- a/src/hooks/useDocumentRoot.ts
+++ b/src/hooks/useDocumentRoot.ts
@@ -1,8 +1,9 @@
-import React, { useId } from 'react';
+import React from 'react';
 import { Access, DocumentType } from '@tdev-api/document';
 import DocumentRoot, { TypeMeta } from '@tdev-models/DocumentRoot';
 import { useStore } from '@tdev-hooks/useStore';
 import { Config } from '@tdev-api/documentRoot';
+import { useDummyId } from './useDummyId';
 
 /**
  * 1. create a dummy documentRoot with default (meta) data
@@ -21,7 +22,7 @@ export const useDocumentRoot = <Type extends DocumentType>(
     access: Partial<Config> = {},
     skipCreate?: boolean
 ) => {
-    const defaultRootDocId = useId();
+    const defaultRootDocId = useDummyId();
     const userStore = useStore('userStore');
     const documentRootStore = useStore('documentRootStore');
     const [dummyDocumentRoot] = React.useState<DocumentRoot<Type>>(
@@ -58,7 +59,7 @@ export const useDocumentRoot = <Type extends DocumentType>(
         return () => {
             documentRootStore.removeFromStore(defaultRootDocId, false);
         };
-    }, []);
+    }, [documentRootStore]);
 
     React.useEffect(() => {
         if (!userStore.isUserSwitched || !id) {

--- a/src/hooks/useDummyId.ts
+++ b/src/hooks/useDummyId.ts
@@ -1,0 +1,44 @@
+import React from 'react';
+
+export const DUMMY_PREFIX = 'dummy-' as const;
+export const TEMP_PREFIX = `${DUMMY_PREFIX}temp-` as const;
+
+/**
+ * Checks if a given id is a dummy id.
+ * @param id of a document
+ * @returns whether an id starts with 'dummy-' prefix
+ */
+export const isDummyId = (id: string) => {
+    return id.startsWith(DUMMY_PREFIX);
+};
+
+/**
+ * Checks if a given id is a temporary id and could potentially
+ *          be loaded/persisted from the backend
+ * @param id of a document
+ * @returns whether an id starts with 'dummy-temp-' prefix
+ */
+export const isTempId = (id: string) => {
+    return id.startsWith(TEMP_PREFIX);
+};
+
+/**
+ * @param refId optional id that references a parent (e.g. the root document)
+ *              when a refId is provided, it is checked wheter it is a dummyId:
+ *              -> refId is a dummyId: prefix with 'dummy-'
+ *              -> refId isn't a dummyId: prefix with 'dummy-temp-'
+ * @returns a unique dummy ID
+ * @example
+ * ```tsx
+ * useDummyId() # => 'dummy-:r1:`
+ * useDummyId('dummy-:r2:') # => 'dummy-:r3:`
+ * useDummyId('2c8f24f4-...') # => 'dummy-temp-:r3:`
+ * ```
+ */
+export const useDummyId = (refId?: string) => {
+    const id = React.useId();
+    if (!refId || isDummyId(refId)) {
+        return `${DUMMY_PREFIX}${id}`;
+    }
+    return `${TEMP_PREFIX}${id}`;
+};

--- a/src/hooks/useFirstMainDocument.ts
+++ b/src/hooks/useFirstMainDocument.ts
@@ -1,10 +1,11 @@
-import React, { useId } from 'react';
+import React from 'react';
 import { DocumentType } from '@tdev-api/document';
 import { TypeMeta } from '@tdev-models/DocumentRoot';
 import { CreateDocumentModel } from '@tdev-stores/DocumentStore';
 import { useDocumentRoot } from '@tdev-hooks/useDocumentRoot';
 import { useStore } from '@tdev-hooks/useStore';
 import { Config } from '@tdev-api/documentRoot';
+import { isDummyId, useDummyId } from './useDummyId';
 
 export const DUMMY_DOCUMENT_ID = 'dummy' as const;
 
@@ -22,7 +23,7 @@ export const useFirstMainDocument = <Type extends DocumentType>(
     createDocument: boolean = true,
     access: Partial<Config> = {}
 ) => {
-    const defaultDocId = useId();
+    const defaultDocId = useDummyId(documentRootId);
     const documentRoot = useDocumentRoot(documentRootId, meta, true, access);
     const userStore = useStore('userStore');
     const documentStore = useStore('documentStore');

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -3,6 +3,7 @@ import { DocumentRootBase as DocumentRootProps } from '@tdev-api/documentRoot';
 import { DocumentRootStore } from '@tdev-stores/DocumentRootStore';
 import { Access, DocumentType, TypeDataMapping, TypeModelMapping } from '@tdev-api/document';
 import { highestAccess, NoneAccess, RWAccess } from './helpers/accessPolicy';
+import { isDummyId } from '@tdev-hooks/useDummyId';
 
 export abstract class TypeMeta<T extends DocumentType> {
     readonly pagePosition: number;
@@ -51,6 +52,11 @@ class DocumentRoot<T extends DocumentType> {
         if (!isDummy) {
             this.setLoaded();
         }
+    }
+
+    @action
+    isLoadable() {
+        return !isDummyId(this.id) && this.store.root.sessionStore.isLoggedIn;
     }
 
     @action

--- a/src/models/DocumentRoot.ts
+++ b/src/models/DocumentRoot.ts
@@ -37,6 +37,7 @@ class DocumentRoot<T extends DocumentType> {
      * in offline mode.
      */
     readonly isDummy: boolean;
+    readonly initializedAt: number;
 
     @observable accessor isLoaded: boolean = false;
     @observable accessor _access: Access;
@@ -49,13 +50,14 @@ class DocumentRoot<T extends DocumentType> {
         this._access = props.access;
         this._sharedAccess = props.sharedAccess;
         this.isDummy = !!isDummy;
+        this.initializedAt = Date.now();
         if (!isDummy) {
             this.setLoaded();
         }
     }
 
-    @action
-    isLoadable() {
+    @computed
+    get isLoadable() {
         return !isDummyId(this.id) && this.store.root.sessionStore.isLoggedIn;
     }
 

--- a/src/models/iDocument.ts
+++ b/src/models/iDocument.ts
@@ -1,10 +1,12 @@
-import { action, computed, IReactionDisposer, observable, reaction } from 'mobx';
+import { action, computed, IReactionDisposer, observable, reaction, set } from 'mobx';
 import { Document as DocumentProps, TypeDataMapping, DocumentType } from '@tdev-api/document';
 import DocumentStore from '@tdev-stores/DocumentStore';
 import _ from 'es-toolkit/compat';
 import { ApiState } from '@tdev-stores/iStore';
 import { NoneAccess, ROAccess, RWAccess } from './helpers/accessPolicy';
 import type iSideEffect from './SideEffects/iSideEffect';
+import { DUMMY_DOCUMENT_ID } from '@tdev-hooks/useFirstMainDocument';
+import { isDummyId, isTempId } from '@tdev-hooks/useDummyId';
 
 /**
  * normally, save only once all 1000ms
@@ -73,6 +75,10 @@ abstract class iDocument<Type extends DocumentType> {
                 }
             }
         );
+    }
+
+    get isLoadable() {
+        return !isTempId(this.id) && this.store.canSave;
     }
 
     @computed

--- a/src/stores/SessionStore.ts
+++ b/src/stores/SessionStore.ts
@@ -4,7 +4,7 @@ import { RootStore } from '@tdev-stores/rootStore';
 import { logout } from '@tdev-api/user';
 import Storage, { PersistedData, StorageKey } from '@tdev-stores/utils/Storage';
 import iStore from '@tdev-stores/iStore';
-import api from '@tdev-api/base';
+import api, { checkLogin as apiCheckLogin } from '@tdev-api/base';
 import { mdiContentSaveOffOutline, mdiDatabaseSyncOutline, mdiHarddisk } from '@mdi/js';
 
 class State {
@@ -15,7 +15,7 @@ class State {
     constructor() {}
 }
 
-export class SessionStore extends iStore {
+export class SessionStore extends iStore<'checkLogin'> {
     readonly root: RootStore;
 
     @observable.ref private accessor stateRef: State = new State();

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -278,7 +278,7 @@ function Root({ children }: { children: React.ReactNode }) {
             <StoresProvider value={rootStore}>
                 <MsalWrapper>{children}</MsalWrapper>
                 <RemoteNavigationHandler />
-                {!OFFLINE_API && <LoggedOutOverlay delayMs={5000} />}
+                {!OFFLINE_API && <LoggedOutOverlay delayMs={5_000} stalledCheckIntervalMs={15_000} />}
             </StoresProvider>
         </>
     );

--- a/src/theme/Root.tsx
+++ b/src/theme/Root.tsx
@@ -243,6 +243,7 @@ function Root({ children }: { children: React.ReactNode }) {
     }, [SENTRY_DSN]);
 
     React.useEffect(() => {
+        let timeoutId: ReturnType<typeof setTimeout>;
         const handleVisibilityChange = () => {
             if (document.hidden) {
                 /**
@@ -255,15 +256,17 @@ function Root({ children }: { children: React.ReactNode }) {
                  * make sure to reconnect the socket when the user returns to the page
                  * The delay is added to avoid reconnecting too quickly
                  */
-                const timeoutId = setTimeout(() => {
+                timeoutId = setTimeout(() => {
                     rootStore.socketStore.reconnect();
                 }, 3000);
-                return () => clearTimeout(timeoutId);
             }
         };
 
         document.addEventListener('visibilitychange', handleVisibilityChange);
-        return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
+        return () => {
+            document.removeEventListener('visibilitychange', handleVisibilityChange);
+            clearTimeout(timeoutId);
+        };
     }, [rootStore]);
 
     return (


### PR DESCRIPTION
This PR tries to fix the issue with dummy roots present in a connected client, by:
- adding refetch-queue for unfetched document roots (e.g. when trying to create a doc root, but it is already present, then trigger a refetch of it. Stop refetching after 5 tries)
- tracking loadable document roots and show warning, when such a dummy doc that could be loaded, exists longer than 5s (so the document root was obviously not loaded)
- display an overlay, when there are unloaded dummy roots. the check happens every 15s.


additionally
- fix a rehydration error
- add batched docRoots in one action